### PR TITLE
v1.1.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,11 +37,7 @@ A command-line tool to unzip/extract various archive formats, including nested a
 ## Quickstart Commands
 
 - Run in PowerShell:
-
-```powershell
-# From repo root
-poetry run main
-
+- 
 ```powershell
 # From repo root
 poetry run main
@@ -62,7 +58,7 @@ poetry run pytest -q
 - Smoke test the CLI:
 
 ```powershell
-poetry run python -m complex_unzip_tool_v2 --help
+poetry run main --help
 ```
 
 - Build (packaging helper):

--- a/complex_unzip_tool_v2/__init__.py
+++ b/complex_unzip_tool_v2/__init__.py
@@ -1,5 +1,5 @@
 """Complex Unzip Tool v2 - A powerful archive extraction utility."""
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 __author__ = "Rozx"
 __email__ = "lisida900710@gmail.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "complex-unzip-tool-v2"
-version = "1.1.2"
+version = "1.1.3"
 description = "A powerful tool for extracting complex archive files with password support and multipart handling"
 authors = ["Rozx <lisida900710@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Release Summary v1.1.3 / 发布摘要 v1.1.3

## 🔒 Safer Multipart Grouping / 更安全的多分卷归组

**Fixed:** Cross-folder part mixing that caused extraction failures / **修复：** 跨文件夹分卷混合导致的提取失败

### What Changed / 变更内容
- Multipart archives now group only within the same directory tree / 多分卷档案现仅在同一目录树内归组
- Removed fuzzy matching to prevent accidental cross-group moves / 移除模糊匹配以防意外跨组移动
- Added strict base-name validation for part grouping / 为分卷归组添加严格的基础名验证

### Problem Solved / 解决的问题
When extracting parent directories with multiple subfolders containing same-named archives (e.g., `10435.7z.001`, `10423.7z.001`), parts could be incorrectly moved between folders, causing "File is not a valid archive" errors.

当提取包含多个子文件夹且含有同名档案的父目录时（如 `10435.7z.001`、`10423.7z.001`），分卷可能被错误地在文件夹间移动，导致"不是有效档案"错误。

### Impact / 影响
- ✅ No more cross-folder part contamination / 不再出现跨文件夹分卷污染
- ✅ Predictable extraction behavior for organized archives / 有组织档案的可预测提取行为
- ✅ Zero breaking changes to CLI / CLI 零破坏性变更

### Quick Test / 快速测试
```powershell
poetry run pytest -q  # All tests pass / 所有测试通过
poetry run main "E:\testPath"  # Try on real data / 在真实数据上测试
```