### PR TITLE
V1.2.1 bug fixes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.2.1
 commit = False
 tag = False
 

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,393 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@kilocode/plugin": "7.3.40",
+        "@opencode-ai/plugin": "1.1.40"
+      }
+    },
+    "node_modules/@kilocode/plugin": {
+      "version": "7.3.40",
+      "resolved": "https://registry.npmjs.org/@kilocode/plugin/-/plugin-7.3.40.tgz",
+      "integrity": "sha512-3Go8kJbbb0PvvBESqBHO5TgBcnd+aYfDi5jiQPDgT45mX0X8a5qvDx1ilAn4MZRQtfyFCMLgc3FeZ3n/N7dAhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kilocode/sdk": "7.3.40",
+        "effect": "4.0.0-beta.59",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.2.6",
+        "@opentui/keymap": ">=0.2.6",
+        "@opentui/solid": ">=0.2.6"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@kilocode/sdk": {
+      "version": "7.3.40",
+      "resolved": "https://registry.npmjs.org/@kilocode/sdk/-/sdk-7.3.40.tgz",
+      "integrity": "sha512-B2svBl8/9c32Q+LtWPTXNDj7x+Dge5eMfAYH9n8ckrfNY6ZRY09uCl4gD9vrqgbc3n5GPw+h2/TNQ6AHHD+jZg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.1.40",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.1.40",
+        "zod": "4.1.8"
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.1.40",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.59",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.59.tgz",
+      "integrity": "sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.6.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^6.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^1.11.9",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/msgpackr": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.13.tgz",
+      "integrity": "sha512-pWaxg0k1iiNdkAayUQ7Zlz/vYNfVefUttmHxqFcQjjtyqFa3w4x5rginOEzy/GvbWhBDD9K65/ZXyq8qz8utaQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,8 +159,12 @@ The tool normalizes “cloaked” filenames before grouping/extracting. This is 
 Safety guards (never rename these):
 - Files that already have a proper multipart format are left as-is, e.g.:
   - `.7z.001`, `.7z.002`, ...
+  - `.<ext>.001`, `.<ext>.002`, ... (7-Zip generic numbered split of any extension, e.g. `.zip.001`, `.rar.001`, `.iso.001`; 3+ zero-padded digits)
   - `.r00`, `.r01`, ... (RAR continuation)
   - `.z01`, `.z02`, ... (ZIP continuation)
+  - `.zx01`, `.zx02`, ... (ZIPX continuation)
+  - `.a01`, `.a02`, ... (ARJ continuation)
+  - `.c00`, `.c01`, ... (ACE continuation)
   - `.tar.gz.001`, `.tar.bz2.001`, `.tar.xz.001`
   - `.part1.rar`, `.part2.rar`
 - Files that already end with a proper single archive extension are left as-is, e.g.:
@@ -220,8 +224,12 @@ When extracting an archive that itself contains multipart archives (e.g., a .7z 
 - Primary vs continuation identification:
   - 7z volumes: primary is `.7z.001`; continuations are `.7z.002+`.
   - TAR multipart: primary is `.tar.gz/.tar.bz2/.tar.xz.001`; continuations are `.002+`.
+  - Generic 7-Zip split (any extension): primary is `name.<ext>.001`; continuations are `name.<ext>.002+` (3+ zero-padded digits; covers `.zip.001`, `.rar.001`, `.iso.001`, …).
   - RAR volumes: primary is `.rar` or `.part1.rar`; continuations are `.r00`, `.r01`, … and `.part2+.rar`.
   - ZIP spanned: primary is `.zip`; continuations are `.z01`, `.z02`, …
+  - ZIPX spanned: primary is `.zipx`; continuations are `.zx01`, `.zx02`, …
+  - ARJ volumes: primary is `.arj`; continuations are `.a01`, `.a02`, …
+  - ACE volumes: primary is `.ace`; continuations are `.c00`, `.c01`, … (classification only — the bundled 7-Zip cannot extract ACE, so such sets fail extraction and their parts are retained).
 
 - Behavior:
   - Continuation parts detected during nested extraction are NOT treated as nested archives and are NOT added to `final_files`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,17 @@ poetry install
 - Run tests:
 
 ```powershell
-poetry run pytest -q
+poetry run pytest -q                                        # all tests
+poetry run pytest tests/test_archive_utils.py -q            # one file
+poetry run pytest tests/test_archive_utils.py::test_build_7z_extract_cmd -q   # one test
+```
+
+- Lint / format / type-check:
+
+```powershell
+poetry run black complex_unzip_tool_v2/ tests/   # format (line-length 88)
+poetry run flake8 complex_unzip_tool_v2/ tests/  # lint
+poetry run mypy complex_unzip_tool_v2/           # type check (strict)
 ```
 
 - Smoke test the CLI:
@@ -91,14 +101,17 @@ Note: The project bundles `7z/7z.exe`; code paths may assume this local binary.
 
 ## Change Workflow
 1) Branch and plan a minimal change set.
-2) Add/adjust tests under `tests/` (write failing test first if practical).
-3) Implement changes in `complex_unzip_tool_v2/` (keep diffs small and focused).
+2) **TDD: write a failing test first** under `tests/` (regression test for a bug, or a spec test for new behavior); confirm it fails for the right reason.
+3) Implement the minimum change in `complex_unzip_tool_v2/` to make it pass (keep diffs small and focused), then refactor with the test green.
 4) Run quality gates locally:
    - Build: ensure code runs (smoke test CLI)
    - Tests: `poetry run pytest -q`
    - Lint/Typecheck: if configured in `pyproject.toml`
 5) Update docs (`README.md`) if user-facing behavior changes.
 6) Commit with a clear message and open a PR with a short checklist.
+
+## Spec-driven development (OpenSpec)
+This repo uses **OpenSpec**. Active specs live in `openspec/specs/`, proposed changes in `openspec/changes/`, and project conventions in `openspec/project.md`. For non-trivial features or behavior changes, create/advance an OpenSpec change (via the `openspec-*` skills) instead of ad-hoc edits, then archive it once implemented. Small bugfixes can skip this, but still follow TDD.
 
 ## Quality Gates (Definition of Done)
 - Build/Run: CLI `--help` works without errors.
@@ -108,9 +121,11 @@ Note: The project bundles `7z/7z.exe`; code paths may assume this local binary.
 - Docs updated when behavior or usage changes.
 
 ## Testing Guidelines
+- **Always use TDD**: write the failing test before the implementation (see Change Workflow).
 - Put tests in `tests/`, named `test_*.py`.
 - Cover happy path and at least one edge case (e.g., missing password, invalid archive, cloaked file detection).
 - Prefer small, deterministic examples; avoid large fixtures unless needed.
+- Tests do **not** require the real `7z.exe`: mock the subprocess/extraction calls with `monkeypatch` and use the `tmp_path` fixture for filesystem effects. Pure helpers (regex / grouping / uncloaking / path normalization) are tested directly. See `tests/test_archive_utils.py` for the mocking pattern.
 
 ## Coding Conventions
 - Keep functions small; prefer pure helpers in `modules/` when feasible.
@@ -167,8 +182,8 @@ Resolution flow:
 2) Iterate rules by `priority` (desc). If a rule matches, build the new filename:
    - Multipart part numbers are normalized to 3 digits (e.g., `1` -> `001`).
    - If `type` is `auto`, we try to detect via `archive_extension_utils.detect_archive_extension`.
-3) Optional verification: the detector attempts to confirm the archive type via signature when possible; it’s lenient for cloaked files to avoid blocking normalization.
-4) Apply rename only if the new filename differs and passes the basic checks.
+3) Signature gate (`_verify_with_signature`): if the filename carries an explicit archive token — `.7z` / `.rar` / `.zip` (matched by `ARCHIVE_TOKEN_RE`) — the rename is trusted, because continuation parts (e.g. `name.7z.002删除`) legitimately carry no magic-byte signature. If there is NO such token, the type was only *guessed* from a trailing number, so a real archive signature (`archive_extension_utils.detect_archive_extension`) is required before renaming — this stops ordinary files from being turned into fake parts.
+4) Apply rename only if the new filename differs and passes the signature gate.
 
 Examples (intended outcomes):
 - `11111.7z删除` -> `11111.7z`
@@ -184,6 +199,20 @@ Where to change rules:
 Testing:
 - See `tests/test_cloaked_file_detector.py` for unit tests covering rule matching and safety guards.
 - Run tests with `poetry run pytest -q`.
+
+## Rename history (revert-on-failure)
+Because uncloaking renames source files *in place* before extraction, a failed extraction would otherwise leave the user with renamed files they can no longer recognize. `RenameHistory` (`complex_unzip_tool_v2/modules/rename_history.py`) makes uncloaking reversible.
+
+- Every successful uncloak rename is recorded (Step 4) and persisted eagerly via atomic temp+replace to `<input_root>/.unzip-rename-history.tmp.json`, so a crash mid-run still leaves a recoverable record.
+- Entries are bound to their owning `ArchiveGroup` after grouping (Step 5).
+- Per group, after extraction: on **success** the entries are cleared; on **failure** they are reverted (files renamed back to their original cloaked names). This is wired through `_reconcile_rename_history()` in `main.py`, which mirrors `_should_delete_original_archives()` — if originals are being kept, names are put back; if they are being deleted, history is cleared.
+- On startup, a leftover history file from a previous crashed run is detected and the user is prompted to revert it (`_maybe_recover_pending_renames`).
+- Unbound entries (renamed file vanished before grouping) are reverted defensively at the end; the on-disk file is deleted on a clean run (`finalize`).
+- Tests: `tests/test_rename_history.py`.
+
+## Cleanup safety guards (do not break these)
+- **Never delete originals on password failure.** All source deletion is gated by `_should_delete_original_archives()`, which returns `False` whenever `password_failed_archives` is non-empty. Deletion defaults to the Recycle Bin (`send2trash`); `--permanent-delete` overrides.
+- **Multipart retention on failure.** When a multipart set fails to extract, the source parts are retained; only tool-created temp folders are cleaned (logs say "Retained source multipart parts due to extraction failure").
 
 ## Nested multipart handling (inside containers)
 When extracting an archive that itself contains multipart archives (e.g., a .7z containing another multi-part set), the tool now relocates continuation parts into their corresponding multipart group directory so that top‑level multipart extraction has all required volumes. Primary parts are still the only ones considered for recursive nested extraction.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Always use TDD
+
+This repository follows **Test-Driven Development**. For every feature or bugfix:
+
+1. Write a failing test first (regression test that reproduces the bug, or a test that specifies the new behavior).
+2. Confirm it fails for the right reason (`poetry run pytest tests/<file>::<test> -q`).
+3. Write the minimum code to make it pass.
+4. Refactor with the test green.
+
+Tests do **not** require the real `7z.exe` — the extraction engine's subprocess calls are mocked with `monkeypatch` and filesystem effects use the `tmp_path` fixture. Pure helpers (regex/grouping/uncloaking/path-normalization) are tested directly. Prefer this style: small, deterministic, no real archives.
+
+## Commands
+
+```powershell
+poetry install                                  # install deps (Poetry, Python 3.11+)
+
+poetry run pytest -q                            # run all tests
+poetry run pytest tests/test_archive_utils.py -q          # one file
+poetry run pytest tests/test_archive_utils.py::test_build_7z_extract_cmd -q   # one test
+poetry run pytest -v                            # verbose
+
+poetry run black complex_unzip_tool_v2/ tests/  # format (line-length 88)
+poetry run flake8 complex_unzip_tool_v2/ tests/ # lint
+poetry run mypy complex_unzip_tool_v2/          # type check (strict: disallow_untyped_defs)
+
+poetry run main "C:\path\to\archives"           # run the tool (alias: poetry run cuz)
+poetry run main --help                          # CLI smoke test
+poetry run build                                # build standalone exe -> dist/
+poetry run bump-patch | bump-minor | bump-major # version bump (bump2version)
+```
+
+**Quality gates before committing:** `pytest -q` green, `flake8` clean, `mypy` clean, `black` applied, `--help` works.
+
+Platform is **Windows-only** (bundles `./7z/7z.exe`); the default shell is PowerShell.
+
+## Architecture
+
+A CLI that extracts complex archives: password-protected, multipart, nested, and **cloaked** (disguised filenames). Built on Typer + Rich, driving the bundled 7-Zip binary via subprocess.
+
+### Extraction pipeline (the big picture)
+
+[main.py](complex_unzip_tool_v2/main.py) `extract_files()` is a fixed 9-step pipeline. Understanding the *ordering* is essential because later steps depend on earlier ones:
+
+1. Set up `unzipped/` output folder (name from `const.OUTPUT_FOLDER`).
+2. Load passwords ([password_util.py](complex_unzip_tool_v2/modules/password_util.py) → [PasswordBook](complex_unzip_tool_v2/classes/PasswordBook.py)).
+3. Scan input paths into a flat file list ([file_utils.py](complex_unzip_tool_v2/modules/file_utils.py) `read_dir`).
+4. **Uncloak** disguised filenames in place ([cloaked_file_detector.py](complex_unzip_tool_v2/modules/cloaked_file_detector.py)) — every rename is recorded in a [RenameHistory](complex_unzip_tool_v2/modules/rename_history.py).
+5. Group files into `ArchiveGroup`s by name+directory ([file_utils.py](complex_unzip_tool_v2/modules/file_utils.py) `create_groups_by_name`); bind rename-history entries to their group.
+6. Print group summary.
+7. **Single archives first** — extracting them may surface *contained* multipart sets, which get registered as new groups (`ensure_contained_multipart_groups`) for step 8.
+8. **Multipart archives** — extracted after singles so all volumes (including ones found inside containers and relocated in step 7's reconciliation pass) are present.
+9. Final summary; save newly learned passwords; revert/finalize rename history.
+
+The recursive engine is [archive_utils.py](complex_unzip_tool_v2/modules/archive_utils.py) `extract_nested_archives()`. It validates each file with 7-Zip, tries every password (empty password first), recurses into nested archives into per-archive subfolders, and returns a result dict (`success`, `final_files`, `password_failed_archives`, `candidate_multipart_parts`, …). `main.py` then moves `final_files` into the output folder preserving structure.
+
+### Multipart: primary vs. continuation (cross-cutting invariant)
+
+7-Zip must be invoked on the **primary** volume, never a continuation part. This distinction is duplicated across several files and must stay consistent:
+
+- [regex.py](complex_unzip_tool_v2/modules/regex.py) — `multipart_regex` (is this any part of a set?) and `first_part_regex` (is this an unambiguous entry point?).
+- [ArchiveGroup.py](complex_unzip_tool_v2/classes/ArchiveGroup.py) — `_entry_point_priority()` ranks files so `mainArchiveFile` is always the right entry point (e.g. spanned ZIP keeps `.zip`, not `.z01`; volume RAR keeps `.rar`, not `.r00`), regardless of insertion order. `try_set_alternative_main_archive()` is the fallback when the chosen main fails.
+- `archive_utils.py` / `file_utils.py` — relocate continuation parts (`.7z.002+`, `.r00+`, `.z01+`, `.part2+.rar`) next to their primary instead of treating them as nested archives or final files.
+
+Primary/continuation rules per format: `.7z.001` primary / `.7z.002+` cont; `.tar.{gz,bz2,xz}.001` primary / `.002+` cont; `.rar` or `.part1.rar` primary / `.r00+`,`.part2+.rar` cont; `.zip` primary / `.z01+` cont.
+
+### Cloaked-file detection + signature gate
+
+[CloakedFileDetector](complex_unzip_tool_v2/modules/cloaked_file_detector.py) normalizes disguised names (e.g. `11111.7z.00删1` → `11111.7z.001`) using priority-ordered JSON rules in [config/cloaked_file_rules.json](complex_unzip_tool_v2/config/cloaked_file_rules.json). Safety gate in `_verify_with_signature()`: if the name carries an explicit archive token (`.7z`/`.rar`/`.zip`, via `ARCHIVE_TOKEN_RE`) the rename is trusted (continuation parts legitimately have no signature); otherwise the type was only *guessed* from a trailing number and a real magic-byte signature (`archive_extension_utils.detect_archive_extension`) is required — this prevents renaming ordinary files into fake parts. Editing rules = edit the JSON, not the code.
+
+### Rename-history revert-on-failure
+
+[RenameHistory](complex_unzip_tool_v2/modules/rename_history.py) persists every uncloak rename eagerly (atomic temp+replace) to `<input_root>/.unzip-rename-history.tmp.json`. Per group: on extraction **success** the entries are cleared; on **failure** they are reverted so the user can recover the original (still-cloaked) files manually (`_reconcile_rename_history` in main.py mirrors `_should_delete_original_archives`). Leftover history from a crashed run is offered for recovery at startup (`_maybe_recover_pending_renames`).
+
+### Other invariants
+
+- **Never delete originals on password failure.** `_should_delete_original_archives()` gates all source deletion on an empty `password_failed_archives`. Deletion defaults to Recycle Bin (`send2trash`); `--permanent-delete` overrides.
+- **Multipart retention on failure.** When a multipart set fails to extract, source parts are kept; only tool-created temp folders are removed.
+- Domain errors live in [ArchiveExceptions.py](complex_unzip_tool_v2/classes/ArchiveExceptions.py) / [ArchiveTypes.py](complex_unzip_tool_v2/classes/ArchiveTypes.py); `_raise_for_7z_error()` maps 7-Zip output to them (notably "not an archive" → `ArchiveUnsupportedError`, **not** corruption, so regular files like `.mp4` aren't flagged as corrupt during nested scans).
+- All user-facing strings are **bilingual (English 中文)**; output goes through [rich_utils.py](complex_unzip_tool_v2/modules/rich_utils.py) helpers — match that style, don't `print()` directly.
+
+## Conventions & workflow
+
+- Detailed conventions live in [AGENTS.md](AGENTS.md) (operating guide, passwords, uncloaking rules, nested handling) and [openspec/project.md](openspec/project.md). Read those before larger changes; if anything conflicts with [README.md](README.md), README wins.
+- This project uses **OpenSpec** for spec-driven development. Specs are in `openspec/specs/`, proposed changes in `openspec/changes/`. For non-trivial features/changes, follow the OpenSpec workflow (the `openspec-*` skills) rather than ad-hoc edits.
+- Keep PRs atomic (~<300 lines), reuse existing utilities, don't add dependencies without justification, and never modify bundled binaries under `7z/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,9 @@ The recursive engine is [archive_utils.py](complex_unzip_tool_v2/modules/archive
 
 - [regex.py](complex_unzip_tool_v2/modules/regex.py) — `multipart_regex` (is this any part of a set?) and `first_part_regex` (is this an unambiguous entry point?).
 - [ArchiveGroup.py](complex_unzip_tool_v2/classes/ArchiveGroup.py) — `_entry_point_priority()` ranks files so `mainArchiveFile` is always the right entry point (e.g. spanned ZIP keeps `.zip`, not `.z01`; volume RAR keeps `.rar`, not `.r00`), regardless of insertion order. `try_set_alternative_main_archive()` is the fallback when the chosen main fails.
-- `archive_utils.py` / `file_utils.py` — relocate continuation parts (`.7z.002+`, `.r00+`, `.z01+`, `.part2+.rar`) next to their primary instead of treating them as nested archives or final files.
+- `archive_utils.py` / `file_utils.py` — relocate continuation parts (`.7z.002+`, `.<ext>.002+`, `.r00+`, `.z01+`, `.zx01+`, `.a01+`, `.c00+`, `.part2+.rar`) next to their primary instead of treating them as nested archives or final files.
 
-Primary/continuation rules per format: `.7z.001` primary / `.7z.002+` cont; `.tar.{gz,bz2,xz}.001` primary / `.002+` cont; `.rar` or `.part1.rar` primary / `.r00+`,`.part2+.rar` cont; `.zip` primary / `.z01+` cont.
+Primary/continuation rules per format: `.7z.001` primary / `.7z.002+` cont; `.tar.{gz,bz2,xz}.001` primary / `.002+` cont; **generic 7-Zip split `name.<ext>.001` primary / `name.<ext>.002+` cont** (any `<ext>` — covers `.zip.001`, `.rar.001`, `.iso.001`, …; 3+ zero-padded digits); `.rar` or `.part1.rar` primary / `.r00+`,`.part2+.rar` cont; `.zip` primary / `.z01+` cont; `.zipx` primary / `.zx01+` cont; `.arj` primary / `.a01+` cont; `.ace` primary / `.c00+` cont (ACE is grouped/classified only — the bundled 7-Zip cannot extract ACE, so such sets fail extraction and parts are retained).
 
 ### Cloaked-file detection + signature gate
 

--- a/RelaseNotes/RELEASE_NOTES_v1.2.1.md
+++ b/RelaseNotes/RELEASE_NOTES_v1.2.1.md
@@ -1,8 +1,8 @@
 # Release Notes v1.2.1 / 发布说明 v1.2.1
 
-A focused patch release fixing two **data-loss** bugs in cloaked-file detection and archive grouping. No breaking changes.
+A focused patch release fixing two **data-loss** bugs in cloaked-file detection and archive grouping, and **expanding multi-part archive format detection** to all archive types. No breaking changes.
 
-一个聚焦的补丁版本，修复了伪装文件检测和档案分组中的两个**数据丢失**问题。无破坏性更改。
+一个聚焦的补丁版本，修复了伪装文件检测和档案分组中的两个**数据丢失**问题，并**将多卷档案格式识别扩展到所有档案类型**。无破坏性更改。
 
 ## 🐛 Bug Fixes / 错误修复
 
@@ -38,18 +38,41 @@ Fix: the similarity path now requires `ext1 == ext2`, so only same-family archiv
 
 修复：相似度路径现在要求 `ext1 == ext2`，只有同家族档案才走该路径分组。`.zip` / `.z01` 仍通过精确的 `(base, ext)` 判断分组，而 `foo.7z` 与 `foo.zip` / `foo.z01` 集合并存时保持为独立的单档案组。
 
+## ✨ Improvements / 功能增强
+
+### Expanded multi-part archive format detection / 扩展多卷档案格式识别
+Multi-part sets across **all** archive types are now recognized into a single group with the correct primary as the extraction entry point (previously only `.7z.001`, `.tar.*.001`, `.zip`/`.z01`, `.rar`/`.r00`/`.partN.rar` were handled correctly):
+
+- **7-Zip generic numbered split for any base extension** — `name.<ext>.001` / `.002` … (zero-padded, 3+ digits), with `.001` as the entry point. This covers the common `name.zip.001` (produced by 7-Zip's "Split file") as well as `name.rar.001`, `name.iso.001`, and any other `<ext>`. Previously these were split into wrong groups or treated as single archives, leaving continuation parts behind.
+- **WinZip ZIPX split** — `name.zipx` + `name.zx01` / `.zx02` … (primary `.zipx`).
+- **ARJ multi-volume** — `name.arj` + `name.a01` / `.a02` … (primary `.arj`).
+- **ACE multi-volume** — `name.ace` + `name.c00` / `.c01` … (primary `.ace`). **Note:** ACE sets are now grouped/classified correctly, but the bundled 7-Zip **cannot decode ACE**, so extraction still fails and the source parts are retained (never deleted).
+
+Safety is unchanged: source files are deleted only after a **successful** extraction, so an ordinary numbered file that is not actually an archive (e.g. `report.2024.001`) is retained when extraction fails.
+
+现在**所有**档案类型的多卷集合都会被识别为单个分组，并以正确的主卷作为解压入口（此前仅 `.7z.001`、`.tar.*.001`、`.zip`/`.z01`、`.rar`/`.r00`/`.partN.rar` 能被正确处理）：
+
+- **任意扩展名的 7-Zip 通用编号分卷** —— `name.<ext>.001` / `.002` …（补零、3 位及以上），以 `.001` 为入口。覆盖常见的 `name.zip.001`（7-Zip"拆分文件"生成）以及 `name.rar.001`、`name.iso.001` 等任意 `<ext>`。此前这些会被分到错误的组或当成单个档案，导致续卷被遗留。
+- **WinZip ZIPX 分卷** —— `name.zipx` + `name.zx01` / `.zx02` …（主卷 `.zipx`）。
+- **ARJ 多卷** —— `name.arj` + `name.a01` / `.a02` …（主卷 `.arj`）。
+- **ACE 多卷** —— `name.ace` + `name.c00` / `.c01` …（主卷 `.ace`）。**注意：** ACE 集合现在能被正确分组/识别，但捆绑的 7-Zip **无法解码 ACE**，因此解压仍会失败，且源分卷会被保留（绝不删除）。
+
+安全策略不变：仅在解压**成功**后才删除源文件，所以并非真正档案的编号文件（例如 `report.2024.001`）在解压失败时会被保留。
+
 ## ✅ Test Coverage / 测试覆盖
 
 ### New/Updated Tests / 新增/更新测试
 - **Cloaked false-positives** (`TestCloakedFalsePositives`): a plain `2382` file is not detected/renamed, `uncloak_file` leaves a non-archive digit-suffixed file untouched, and a genuine cloaked 7z first part (real magic bytes) still uncloaks to `secret.7z.001`. Two existing `_verify_with_signature` tests were updated to pin the stricter behavior.
 - **Grouping guard**: unit (`_should_group_files`) regression that `foo.7z` vs `foo.zip` are not grouped, plus an integration (`create_groups_by_name`) regression asserting `foo.7z` stays a standalone group while `foo.zip` / `.z01` / `.z02` form one spanned set.
+- **Multi-part format detection**: a new `test_regex.py` for the pattern catalog, plus `get_archive_base_name`, `_entry_point_priority`, `create_groups_by_name`, nested-continuation, and `ensure_contained_multipart_groups` cases for the generic numbered split and ZIPX/ARJ/ACE formats.
 
-Total: **168 tests pass** (was 163 in v1.2.0, +5 new).
+Total: **199 tests pass** (was 163 in v1.2.0, +36 new).
 
 - **伪装误报**（`TestCloakedFalsePositives`）：普通的 `2382` 文件不会被检测/改名；`uncloak_file` 对非档案的数字后缀文件保持原样；而真正的伪装 7z 首卷（带真实魔数）仍会还原为 `secret.7z.001`。两个原有的 `_verify_with_signature` 测试更新为锁定更严格的行为。
 - **分组守卫**：单元测试（`_should_group_files`）回归确认 `foo.7z` 与 `foo.zip` 不被分到一组；集成测试（`create_groups_by_name`）回归确认 `foo.7z` 保持独立组，而 `foo.zip` / `.z01` / `.z02` 组成一个跨卷集合。
+- **多卷格式识别**：新增 `test_regex.py` 覆盖模式表，以及 `get_archive_base_name`、`_entry_point_priority`、`create_groups_by_name`、嵌套续卷、`ensure_contained_multipart_groups` 针对通用编号分卷与 ZIPX/ARJ/ACE 格式的用例。
 
-总计：**168 个测试通过**（v1.2.0 是 163 个，新增 5 个）。
+总计：**199 个测试通过**（v1.2.0 是 163 个，新增 36 个）。
 
 ## 🚀 Migration Notes / 迁移说明
 

--- a/RelaseNotes/RELEASE_NOTES_v1.2.1.md
+++ b/RelaseNotes/RELEASE_NOTES_v1.2.1.md
@@ -1,0 +1,63 @@
+# Release Notes v1.2.1 / 发布说明 v1.2.1
+
+A focused patch release fixing two **data-loss** bugs in cloaked-file detection and archive grouping. No breaking changes.
+
+一个聚焦的补丁版本，修复了伪装文件检测和档案分组中的两个**数据丢失**问题。无破坏性更改。
+
+## 🐛 Bug Fixes / 错误修复
+
+### Don't rename ordinary files into bogus archive parts / 不再把普通文件改名成伪造的档案分卷
+A plain non-archive file whose name ends in digits (e.g. `2382`) could be renamed into a fake 7z multipart part (`2.7z.382`). It was then swept into a same-named real archive set and **deleted at the end without ever being extracted — losing the user's data**.
+
+Root cause: `_verify_with_signature()` always returned `True`, so the weak extensionless/digit-suffix cloaking rules renamed *any* digit-suffixed file.
+
+The signature gate now distinguishes deliberate cloaking from a guess:
+- If the name carries an explicit archive token (`.7z` / `.rar` / `.zip`, via `ARCHIVE_TOKEN_RE`), the rename is trusted — continuation parts legitimately have no signature (e.g. `something.7z.002删除`).
+- If the type was only **guessed** from a trailing number, a real magic-byte signature is now **required** before renaming.
+- On verification error the tool is now conservative and **skips** the rename instead of assuming the file is valid.
+
+Genuine cloaked first parts and `.7z.00N删` style parts still uncloak correctly.
+
+名字以数字结尾的普通（非档案）文件（例如 `2382`）原先可能被改名成伪造的 7z 分卷（`2.7z.382`），随后被并入同名的真实档案集合，**在结尾被删除却从未解压 —— 导致用户数据丢失**。
+
+根因：`_verify_with_signature()` 永远返回 `True`，导致弱规则（无扩展名 / 尾部数字）会改名**任何**带数字后缀的文件。
+
+签名校验现在区分"有意伪装"与"猜测"：
+- 名字中带有显式档案标记（`.7z` / `.rar` / `.zip`，由 `ARCHIVE_TOKEN_RE` 识别）时，信任改名 —— 续卷本来就没有签名（例如 `something.7z.002删除`）。
+- 若类型只是从尾部数字**猜测**得到，改名前现在**必须**有真实的魔数签名。
+- 校验出错时改为保守处理，**跳过**改名，而不是假定文件有效。
+
+真正的伪装首卷以及 `.7z.00N删` 之类的分卷仍能正确还原。
+
+### Don't merge different archive types that share a base name / 不再合并同名但类型不同的档案
+The similarity check in `_should_group_files` ignored the archive extension, so a standalone `.7z` could be swept into a spanned `.zip` / `.z01` group when they shared a base name and directory. The merged multipart group then **deleted the `.7z` along with the zip parts (data loss)** and mishandled the set during extraction.
+
+Fix: the similarity path now requires `ext1 == ext2`, so only same-family archives group that way. `.zip` / `.z01` still group via the exact `(base, ext)` check, and `foo.7z` stays its own single group alongside the `foo.zip` / `foo.z01` set.
+
+`_should_group_files` 的相似度判断忽略了档案扩展名，导致独立的 `.7z` 在与跨卷 `.zip` / `.z01` 同名且同目录时被并入同一组。合并后的多卷组随后**把 `.7z` 连同 zip 分卷一起删除（数据丢失）**，解压时也处理错误。
+
+修复：相似度路径现在要求 `ext1 == ext2`，只有同家族档案才走该路径分组。`.zip` / `.z01` 仍通过精确的 `(base, ext)` 判断分组，而 `foo.7z` 与 `foo.zip` / `foo.z01` 集合并存时保持为独立的单档案组。
+
+## ✅ Test Coverage / 测试覆盖
+
+### New/Updated Tests / 新增/更新测试
+- **Cloaked false-positives** (`TestCloakedFalsePositives`): a plain `2382` file is not detected/renamed, `uncloak_file` leaves a non-archive digit-suffixed file untouched, and a genuine cloaked 7z first part (real magic bytes) still uncloaks to `secret.7z.001`. Two existing `_verify_with_signature` tests were updated to pin the stricter behavior.
+- **Grouping guard**: unit (`_should_group_files`) regression that `foo.7z` vs `foo.zip` are not grouped, plus an integration (`create_groups_by_name`) regression asserting `foo.7z` stays a standalone group while `foo.zip` / `.z01` / `.z02` form one spanned set.
+
+Total: **168 tests pass** (was 163 in v1.2.0, +5 new).
+
+- **伪装误报**（`TestCloakedFalsePositives`）：普通的 `2382` 文件不会被检测/改名；`uncloak_file` 对非档案的数字后缀文件保持原样；而真正的伪装 7z 首卷（带真实魔数）仍会还原为 `secret.7z.001`。两个原有的 `_verify_with_signature` 测试更新为锁定更严格的行为。
+- **分组守卫**：单元测试（`_should_group_files`）回归确认 `foo.7z` 与 `foo.zip` 不被分到一组；集成测试（`create_groups_by_name`）回归确认 `foo.7z` 保持独立组，而 `foo.zip` / `.z01` / `.z02` 组成一个跨卷集合。
+
+总计：**168 个测试通过**（v1.2.0 是 163 个，新增 5 个）。
+
+## 🚀 Migration Notes / 迁移说明
+
+### For Users / 用户须知
+- **No breaking changes.**
+- Ordinary files whose names happen to end in digits (e.g. `2382`) are no longer mistaken for archive parts, renamed, or deleted — they are left exactly as they are.
+- A standalone `.7z` that shares a base name with a spanned `.zip` set is now extracted on its own instead of being deleted with the zip parts.
+
+- **无破坏性更改。**
+- 名字恰好以数字结尾的普通文件（例如 `2382`）不再被误认为档案分卷、被改名或被删除 —— 它们保持原样。
+- 与跨卷 `.zip` 集合同名的独立 `.7z` 现在会被单独解压，而不会随 zip 分卷一起被删除。

--- a/complex_unzip_tool_v2/__init__.py
+++ b/complex_unzip_tool_v2/__init__.py
@@ -1,5 +1,5 @@
 """Complex Unzip Tool v2 - A powerful archive extraction utility."""
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 __author__ = "Rozx"
 __email__ = "lisida900710@gmail.com"

--- a/complex_unzip_tool_v2/classes/ArchiveGroup.py
+++ b/complex_unzip_tool_v2/classes/ArchiveGroup.py
@@ -23,9 +23,13 @@ def _entry_point_priority(file_path: str) -> int:
         return 100
     if re.search(r"\.part0*1\.rar$", fname):
         return 100
+    # 7-Zip generic numbered split: `name.<ext>.001` is the entry point for ANY
+    # base extension (.zip.001, .rar.001, .iso.001, …). 3+ zero-padded digits.
+    if re.search(r"\.[a-z0-9]+\.0{2,}1$", fname):
+        return 100
 
-    # ZIP/RAR primaries — entry points for spanned ZIP / volume RAR sets,
-    # and also valid for standalone .zip/.rar (lower priority so split-volume
+    # ZIP/RAR/ZIPX/ARJ/ACE primaries — entry points for their multi-volume sets,
+    # and also valid for the standalone archive (lower priority so split-volume
     # primaries above always win when both exist).
     if re.search(r"\.part\d+\.rar$", fname):
         # .partN.rar where N != 1 — continuation, not entry point
@@ -33,6 +37,12 @@ def _entry_point_priority(file_path: str) -> int:
     if fname.endswith(".rar"):
         return 90
     if fname.endswith(".zip"):
+        return 90
+    if fname.endswith(".zipx"):
+        return 90
+    if fname.endswith(".arj"):
+        return 90
+    if fname.endswith(".ace"):
         return 90
 
     return 0

--- a/complex_unzip_tool_v2/modules/archive_utils.py
+++ b/complex_unzip_tool_v2/modules/archive_utils.py
@@ -811,6 +811,35 @@ def extract_nested_archives(
         if fname.endswith(".zip"):
             return f"{fname[:-4]}|zip"
 
+        # ZIPX spanned continuations (.zx01, ...). Primary is .zipx.
+        m = re.match(r"^(.*)\.zx\d{2}$", fname)
+        if m:
+            return f"{m.group(1)}|zipx"
+
+        if fname.endswith(".zipx"):
+            return f"{fname[:-5]}|zipx"
+
+        # ARJ volume continuations (.a01, ...). Primary is .arj.
+        m = re.match(r"^(.*)\.a\d{2}$", fname)
+        if m:
+            return f"{m.group(1)}|arj"
+
+        if fname.endswith(".arj"):
+            return f"{fname[:-4]}|arj"
+
+        # ACE volume continuations (.c00, ...). Primary is .ace.
+        m = re.match(r"^(.*)\.c\d{2}$", fname)
+        if m:
+            return f"{m.group(1)}|ace"
+
+        if fname.endswith(".ace"):
+            return f"{fname[:-4]}|ace"
+
+        # 7-Zip generic numbered split of any extension (.zip.NNN, .rar.NNN, …).
+        m = re.match(r"^(.*)\.([a-z0-9]+)\.(\d{3,})$", fname)
+        if m:
+            return f"{m.group(1)}|{m.group(2)}"
+
         return None
 
     def _is_multipart_primary(file_basename: str) -> bool:
@@ -823,8 +852,18 @@ def extract_nested_archives(
         if re.search(r"\.part(\d+)\.rar$", fname):
             m = re.search(r"\.part(\d+)\.rar$", fname)
             return bool(m and int(m.group(1)) == 1)
-        # .rar and .zip may be the first part of a multipart set
-        return fname.endswith(".rar") or fname.endswith(".zip")
+        # 7-Zip generic numbered split of any extension: .001 is the primary.
+        m = re.search(r"\.[a-z0-9]+\.(\d{3,})$", fname)
+        if m:
+            return int(m.group(1)) == 1
+        # .rar/.zip/.zipx/.arj/.ace may be the first part of a multipart set
+        return (
+            fname.endswith(".rar")
+            or fname.endswith(".zip")
+            or fname.endswith(".zipx")
+            or fname.endswith(".arj")
+            or fname.endswith(".ace")
+        )
 
     def _find_matching_candidate_parts(search_root: str, key: str) -> list[str]:
         """Scan search_root for multipart continuation parts matching key."""
@@ -852,7 +891,21 @@ def extract_nested_archives(
                 if re.search(r"\.z\d{2}$", f_low):
                     matches.append(os.path.join(root, f))
                     continue
+                if re.search(r"\.zx\d{2}$", f_low):
+                    matches.append(os.path.join(root, f))
+                    continue
+                if re.search(r"\.a\d{2}$", f_low):
+                    matches.append(os.path.join(root, f))
+                    continue
+                if re.search(r"\.c\d{2}$", f_low):
+                    matches.append(os.path.join(root, f))
+                    continue
                 m = re.search(r"\.part(\d+)\.rar$", f_low)
+                if m and int(m.group(1)) != 1:
+                    matches.append(os.path.join(root, f))
+                    continue
+                # 7-Zip generic numbered continuation (.zip.002, .rar.002, …)
+                m = re.search(r"\.[a-z0-9]+\.(\d{3,})$", f_low)
                 if m and int(m.group(1)) != 1:
                     matches.append(os.path.join(root, f))
                     continue
@@ -1076,9 +1129,7 @@ def extract_nested_archives(
                 )
 
                 if user_password == "SKIP_ALL":
-                    print_info(
-                        "Skipping all future password prompts 跳过所有未来的密码提示", 2
-                    )
+                    print_info("Skipping all future password prompts 跳过所有未来的密码提示", 2)
                     return False, "", True
                 elif user_password is None:
                     print_info(f"Skipping archive 跳过档案: {archive_name}", 2)
@@ -1165,9 +1216,7 @@ def extract_nested_archives(
                 ) as e:
                     # These are archive-related errors that should stop user password attempts
                     print_error(f"Archive error 档案错误: {str(e)}", 1)
-                    print_info(
-                        "Cannot continue with this archive 无法继续处理此档案", 2
-                    )
+                    print_info("Cannot continue with this archive 无法继续处理此档案", 2)
                     return False, "", False
 
                 except ArchiveError as e:
@@ -1175,9 +1224,7 @@ def extract_nested_archives(
                     error_msg = str(e).lower()
                     if any(keyword in error_msg for keyword in PATH_ERROR_KEYWORDS):
                         print_error(f"File system error 文件系统错误: {str(e)}", 1)
-                        print_info(
-                            "Cannot continue with this archive 无法继续处理此档案", 2
-                        )
+                        print_info("Cannot continue with this archive 无法继续处理此档案", 2)
                         return False, "", False
                     else:
                         # Other archive errors might be password-related, continue
@@ -1185,16 +1232,12 @@ def extract_nested_archives(
                             f"Extraction failed with user password 使用用户密码提取失败: {str(e)}",
                             1,
                         )
-                        print_info(
-                            "Cannot continue with this archive 无法继续处理此档案", 2
-                        )
+                        print_info("Cannot continue with this archive 无法继续处理此档案", 2)
                         return False, "", True
 
                 except Exception as e:
                     print_error(f"Unexpected error 意外错误: {str(e)}", 1)
-                    print_info(
-                        "Cannot continue with this archive 无法继续处理此档案", 2
-                    )
+                    print_info("Cannot continue with this archive 无法继续处理此档案", 2)
                     return False, "", False
         else:
             # If no password was required but extraction still failed, show appropriate message
@@ -1204,9 +1247,7 @@ def extract_nested_archives(
                     1,
                 )
             else:
-                print_warning(
-                    f"Failed to extract archive 提取档案失败: {archive_name}", 1
-                )
+                print_warning(f"Failed to extract archive 提取档案失败: {archive_name}", 1)
 
         return False, "", password_required
 
@@ -1243,7 +1284,9 @@ def extract_nested_archives(
                 # For nested levels, do not treat non-archives as errors; they can appear
                 # due to concurrent processing/cleanup or false positives from signature scans.
                 if depth == 0:
-                    error_msg = f"File is not a valid archive 文件不是有效档案: {current_archive}"
+                    error_msg = (
+                        f"File is not a valid archive 文件不是有效档案: {current_archive}"
+                    )
                     result["errors"].append(error_msg)
                     print_warning(error_msg, 1)
                 else:
@@ -1256,10 +1299,12 @@ def extract_nested_archives(
             # Extract directly to the current output directory to preserve structure
             print_extracting_archive(os.path.basename(current_archive), depth)
 
-            extract_success, used_password, failed_due_to_password = (
-                _tryExtractWithPasswords(
-                    current_archive, current_output, active_progress_bars
-                )
+            (
+                extract_success,
+                used_password,
+                failed_due_to_password,
+            ) = _tryExtractWithPasswords(
+                current_archive, current_output, active_progress_bars
             )
 
             # If extraction failed for a nested multipart primary, attempt to match/move
@@ -1287,12 +1332,14 @@ def extract_nested_archives(
                         )
 
                         # Retry extraction after bringing parts together.
-                        extract_success, used_password, failed_due_to_password = (
-                            _tryExtractWithPasswords(
-                                current_archive,
-                                current_output,
-                                active_progress_bars,
-                            )
+                        (
+                            extract_success,
+                            used_password,
+                            failed_due_to_password,
+                        ) = _tryExtractWithPasswords(
+                            current_archive,
+                            current_output,
+                            active_progress_bars,
                         )
 
                         # If retry still fails, preserve the multipart set by emitting
@@ -1329,9 +1376,7 @@ def extract_nested_archives(
                     f"Testing {len(extracted_files)} extracted files for nested archives",
                     2,
                 )
-                print_info(
-                    f"正在测试 {len(extracted_files)} 个提取的文件是否为嵌套档案...", 3
-                )
+                print_info(f"正在测试 {len(extracted_files)} 个提取的文件是否为嵌套档案...", 3)
 
                 for file_path in extracted_files:
                     file_name = os.path.basename(file_path)
@@ -1377,6 +1422,28 @@ def extract_nested_archives(
                             if m and int(m.group(1)) != 1:
                                 skip_continuation = True
 
+                        # 7-Zip generic numbered split of ANY extension
+                        # (.zip.002, .rar.002, .iso.002, …): only .001 is primary.
+                        if not skip_continuation:
+                            m = re.search(r"\.[a-z0-9]+\.(\d{3,})$", fname)
+                            if m and int(m.group(1)) != 1:
+                                skip_continuation = True
+
+                        # ZIPX spanned: .zx01+ are continuations; primary .zipx
+                        if not skip_continuation:
+                            if re.search(r"\.zx\d{2}$", fname):
+                                skip_continuation = True
+
+                        # ARJ volumes: .a01+ are continuations; primary .arj
+                        if not skip_continuation:
+                            if re.search(r"\.a\d{2}$", fname):
+                                skip_continuation = True
+
+                        # ACE volumes: .c00+ are continuations; primary .ace
+                        if not skip_continuation:
+                            if re.search(r"\.c\d{2}$", fname):
+                                skip_continuation = True
+
                         if skip_continuation:
                             # Attempt to relocate continuation parts to known multipart groups
                             if group_relocator:
@@ -1413,9 +1480,7 @@ def extract_nested_archives(
                     if is_valid_archive(
                         file_path, password=password, seven_zip_path=seven_zip_path
                     ):
-                        print_info(
-                            f"📦 Found nested archive 发现嵌套档案: {file_name}", 3
-                        )
+                        print_info(f"📦 Found nested archive 发现嵌套档案: {file_name}", 3)
                         nested_archives.append(file_path)
                     else:
                         regular_files.append(file_path)
@@ -1456,9 +1521,7 @@ def extract_nested_archives(
                 # If we found nested archives, extract them recursively in their current location
                 if nested_archives:
                     print_info(f"Found {len(nested_archives)} nested archive(s)", 2)
-                    print_info(
-                        f"在深度 {depth} 发现 {len(nested_archives)} 个嵌套档案", 3
-                    )
+                    print_info(f"在深度 {depth} 发现 {len(nested_archives)} 个嵌套档案", 3)
                     for nested_archive in nested_archives:
                         # Skip if already processed in a deeper recursion step
                         if nested_archive in result["extracted_archives"]:
@@ -1480,7 +1543,6 @@ def extract_nested_archives(
 
                         # Derive folder name by stripping known archive suffixes
                         def _derive_folder_name(filename: str) -> str:
-
                             name = filename
                             # Iteratively strip extensions like .zip, .7z, .rar, .tar.gz, .001, .z01, .r00, .part1
                             while True:

--- a/complex_unzip_tool_v2/modules/cloaked_file_detector.py
+++ b/complex_unzip_tool_v2/modules/cloaked_file_detector.py
@@ -20,6 +20,19 @@ from complex_unzip_tool_v2.modules.archive_extension_utils import (
 )
 from complex_unzip_tool_v2.modules.regex import multipart_regex
 
+# An explicit archive-type token (.7z/.rar/.zip) embedded in a filename means the
+# user deliberately named the file as that archive type; the surrounding garbage
+# is just cloaking. Such renames are trustworthy even for continuation parts that
+# carry no signature. When NO token is present, the archive type is only a guess
+# from a trailing numeric suffix and must be confirmed by the file's signature.
+# 文件名中显式带有归档标记(.7z/.rar/.zip)说明用户有意将其命名为该归档类型，
+# 周围的内容只是伪装；此类改名即使对无签名的续卷也是可信的。若没有该标记，
+# 归档类型只是根据尾部数字猜测得到，必须由文件签名确认。
+ARCHIVE_TOKEN_RE = re.compile(
+    r"\.(?:7z|rar|zip)(?:\.|$|[^0-9A-Za-z])",
+    re.IGNORECASE,
+)
+
 
 @dataclass
 class CloakedFileRule:
@@ -384,23 +397,26 @@ class CloakedFileDetector:
             part_number: Part number if this is a multipart archive (e.g., "001", "002")
 
         Returns:
-            True if signature matches or verification not applicable, False otherwise
+            True if there is real evidence the file is an archive, False otherwise.
         """
         try:
-            # Use existing archive extension detection
-            detected_type = detect_archive_extension(file_path)
-            if detected_type:
-                # If we detect a valid archive type, accept it even if different from expected
-                # This handles cases where the rule guesses wrong but the file is still an archive
-                return True  # Any valid archive signature is acceptable
+            filename = os.path.basename(file_path)
 
-            # If no signature detected, be very lenient for cloaked files
-            # Cloaked files by definition don't have proper signatures/extensions
-            return True
+            # The user explicitly named the file as a .7z/.rar/.zip archive; the
+            # rest is just cloaking. Trust it even when this is a continuation
+            # part that legitimately carries no signature (e.g. ".7z.002删除").
+            if ARCHIVE_TOKEN_RE.search(filename):
+                return True
+
+            # No archive token in the name: the type was only guessed from a
+            # trailing numeric suffix (e.g. "2382" -> "2.7z.382"). Require a real
+            # archive signature so ordinary files are never mistaken for parts.
+            detected_type = detect_archive_extension(file_path)
+            return bool(detected_type)
 
         except Exception as e:
             print_warning(f"Could not verify file signature for {file_path}: {e}")
-            return True  # Assume valid if verification fails
+            return False  # Be conservative: do not rename on verification failure
 
     def _build_collision_path(self, file_path: str, normalized_path: str | None) -> str:
         """

--- a/complex_unzip_tool_v2/modules/file_utils.py
+++ b/complex_unzip_tool_v2/modules/file_utils.py
@@ -95,9 +95,13 @@ def get_archive_base_name(file_path: str) -> tuple[str, str]:
 
     # Family-mapped continuation suffixes: all parts must share the family ext
     # so grouping/comparison treats them as the same multi-part set.
+    # Note: .zx must be checked before .z so `.zx01` maps to zipx, not zip.
     family_pattern_map = [
+        (r"\.zx\d{2}$", "zipx"),  # .zx01, .zx02 → zipx family
         (r"\.z\d{2}$", "zip"),  # .z01, .z02 → zip family
         (r"\.r\d{2}$", "rar"),  # .r00, .r01 → rar family
+        (r"\.a\d{2}$", "arj"),  # .a01, .a02 → arj family
+        (r"\.c\d{2}$", "ace"),  # .c00, .c01 → ace family
         (r"\.part\d+\.rar$", "rar"),  # .part1.rar, .part2.rar → rar family
     ]
     for pattern, family_ext in family_pattern_map:
@@ -115,6 +119,14 @@ def get_archive_base_name(file_path: str) -> tuple[str, str]:
                 0
             ]  # Get the archive extension
             return name_without_part, archive_ext
+
+    # 7-Zip generic numbered volume split for ANY base extension: `name.<ext>.NNN`
+    # (zero-padded, 3+ digits). Checked AFTER the specific patterns above so 7z/zip/
+    # tar split parsing is preserved; covers .rar.001, .iso.001, plain .tar.001, etc.
+    # The token immediately before the numeric run is the shared family extension.
+    generic_match = re.search(r"\.([A-Za-z0-9]+)\.\d{3,}$", base_name)
+    if generic_match:
+        return base_name[: generic_match.start()], generic_match.group(1)
 
     # Fallback to regular splitext if no multi-part pattern found
     name, ext = os.path.splitext(base_name)
@@ -527,9 +539,13 @@ def ensure_contained_multipart_groups(
     - `.7z.001`
     - `.tar.(gz|bz2|xz).001`
     - `.part1.rar`
-    And conservative spanned formats when a continuation part exists in the same bucket:
+    - `.<ext>.001` (7-Zip generic numbered split of any extension)
+    And conservative formats only when a continuation part exists in the same bucket:
     - `.zip` when any `.zNN` exists
     - `.rar` when any `.rNN` exists
+    - `.zipx` when any `.zxNN` exists
+    - `.arj` when any `.aNN` exists
+    - `.ace` when any `.cNN` exists
 
     Returns the number of groups created.
     """
@@ -591,17 +607,33 @@ def ensure_contained_multipart_groups(
             if re.search(r"\.part1\.rar$", fname):
                 primary = p
                 break
+            # 7-Zip generic numbered split primary (any extension): name.<ext>.001
+            # The .001 suffix is unambiguous, so the .001 alone is enough.
+            if re.search(r"\.[a-z0-9]+\.0{2,}1$", fname):
+                primary = p
+                break
 
-        # Spanned ZIP and volume RAR are ambiguous; only group if a continuation exists.
+        # Spanned ZIP / volume RAR / ZIPX / ARJ / ACE primaries are ambiguous
+        # (they can be standalone archives); only group if a continuation exists.
         if primary is None:
             has_zip = None
             has_z_cont = False
             has_rar = None
             has_r_cont = False
+            has_zipx = None
+            has_zx_cont = False
+            has_arj = None
+            has_a_cont = False
+            has_ace = None
+            has_c_cont = False
 
             for p in files:
                 fname = os.path.basename(p).lower()
-                if fname.endswith(".zip"):
+                if fname.endswith(".zipx"):
+                    has_zipx = p
+                elif re.search(r"\.zx\d{2}$", fname):
+                    has_zx_cont = True
+                elif fname.endswith(".zip"):
                     has_zip = p
                 elif re.search(r"\.z\d{2}$", fname):
                     has_z_cont = True
@@ -611,12 +643,31 @@ def ensure_contained_multipart_groups(
                 elif re.search(r"\.r\d{2}$", fname):
                     has_r_cont = True
 
+                if fname.endswith(".arj"):
+                    has_arj = p
+                elif re.search(r"\.a\d{2}$", fname):
+                    has_a_cont = True
+
+                if fname.endswith(".ace"):
+                    has_ace = p
+                elif re.search(r"\.c\d{2}$", fname):
+                    has_c_cont = True
+
             if has_zip is not None and has_z_cont:
                 primary = has_zip
                 force_main = has_zip
             elif has_rar is not None and has_r_cont:
                 primary = has_rar
                 force_main = has_rar
+            elif has_zipx is not None and has_zx_cont:
+                primary = has_zipx
+                force_main = has_zipx
+            elif has_arj is not None and has_a_cont:
+                primary = has_arj
+                force_main = has_arj
+            elif has_ace is not None and has_c_cont:
+                primary = has_ace
+                force_main = has_ace
 
         if primary is None:
             continue

--- a/complex_unzip_tool_v2/modules/file_utils.py
+++ b/complex_unzip_tool_v2/modules/file_utils.py
@@ -230,7 +230,12 @@ def _should_group_files(
         if dir1 == dir2:
             return True
 
-    # Third check: Only allow grouping if similarity is very high AND they share exact base name AND same directory
+    # Third check: Only allow grouping if similarity is very high AND they share
+    # exact base name AND same directory AND the same archive family/extension.
+    # The extension guard is essential: without it, unrelated archive types that
+    # merely share a base name (e.g. foo.7z and foo.zip) would be merged into one
+    # group. That corrupts handling — e.g. a standalone .7z swept into a spanned
+    # .zip set gets deleted with the set instead of being extracted on its own.
     similarity = get_string_similarity(group_name1, group_name2)
     if similarity >= 0.95:
         # Extract directory and filename parts
@@ -239,8 +244,9 @@ def _should_group_files(
         name1_only = group_name1.split("-")[-1] if "-" in group_name1 else group_name1
         name2_only = group_name2.split("-")[-1] if "-" in group_name2 else group_name2
 
-        # Only group if the file base names are identical AND they're in the same directory
-        return name1_only == name2_only and dir1 == dir2
+        # Only group if the file base names are identical AND they're in the same
+        # directory AND they belong to the same archive family/extension.
+        return name1_only == name2_only and dir1 == dir2 and ext1 == ext2
 
     # For all other cases, don't group
     return False

--- a/complex_unzip_tool_v2/modules/regex.py
+++ b/complex_unzip_tool_v2/modules/regex.py
@@ -28,13 +28,25 @@ MULTIPART_EXTENSION_PATTERNS = [
 # Check for multipart archives (base case only - after cloaked files have been renamed)
 # These patterns match different multipart archive conventions:
 # - .7z.001, .7z.002, etc. (7z multipart with .00X)
-# - .r00, .r01, .r02, etc. (RAR continuation parts)
-# - .z01, .z02, .z03, etc. (ZIP continuation parts)
 # - .tar.gz.001, .tar.bz2.001, etc. (TAR multipart)
+# - .<ext>.001, .<ext>.002, etc. (7-Zip generic volume split of ANY file, 3+ digits;
+#   covers .zip.001, .rar.001, .iso.001, .bin.001, plain .tar.001, …)
+# - .r00, .r01, etc. (RAR continuation parts)
+# - .z01, .z02, etc. (ZIP continuation parts)
+# - .zx01, .zx02, etc. (ZIPX continuation parts)
+# - .a01, .a02, etc. (ARJ continuation parts)
+# - .c00, .c01, etc. (ACE continuation parts)
 # - .part1.rar, .part2.rar, etc. (RAR part notation)
-# Note: .rar and .zip are ambiguous (could be single files or first parts)
+# Note: .rar / .zip / .zipx / .arj / .ace primaries are ambiguous (could be single
+# files or first parts) and are intentionally NOT matched here.
 multipart_regex = (
-    r"\.(?:7z\.\d{1,3}|tar\.(?:gz|bz2|xz)\.\d{1,3}|r\d{2}|z\d{2}|part\d+\.rar)$"
+    r"\.(?:"
+    r"7z\.\d{1,3}"
+    r"|tar\.(?:gz|bz2|xz)\.\d{1,3}"
+    r"|[A-Za-z0-9]+\.\d{3,}"
+    r"|r\d{2}|z\d{2}|zx\d{2}|a\d{2}|c\d{2}"
+    r"|part\d+\.rar"
+    r")$"
 )
 
 # Check if it's an unambiguous extraction entry point of a multipart archive.
@@ -45,6 +57,9 @@ multipart_regex = (
 # be standalone or the entry point of a spanned set). They are still treated
 # as the highest-priority main archive for spanned ZIP / volume RAR sets via
 # explicit handling in ArchiveGroup.add_file (which knows the full file list).
+# - .<ext>.001 (first volume of a 7-Zip generic numbered split, 3+ digits)
 # IMPORTANT: .r00 and .z01 are intentionally excluded — they are continuation
 # parts, not extraction entry points; 7-Zip must be invoked on .rar / .zip.
-first_part_regex = r"\.(?:7z\.0*1|tar\.(?:gz|bz2|xz)\.0*1|part0*1\.rar)$"
+first_part_regex = (
+    r"\.(?:7z\.0*1|tar\.(?:gz|bz2|xz)\.0*1|[A-Za-z0-9]+\.0{2,}1|part0*1\.rar)$"
+)

--- a/openspec/changes/archive/2026-06-07-expand-multipart-format-detection/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-07-expand-multipart-format-detection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/archive/2026-06-07-expand-multipart-format-detection/design.md
+++ b/openspec/changes/archive/2026-06-07-expand-multipart-format-detection/design.md
@@ -1,0 +1,168 @@
+## Context
+
+Multi-part archive handling rests on one invariant: 7-Zip must be invoked on the
+**primary** volume of a set, never a continuation part. That primary/continuation
+distinction is duplicated across four files — `modules/regex.py`,
+`classes/ArchiveGroup.py`, `modules/file_utils.py`, `modules/archive_utils.py` —
+and must stay consistent (CLAUDE.md calls this out explicitly).
+
+Today the catalog of recognized naming conventions is incomplete. Verified
+current behavior:
+
+| Set | Result today |
+| --- | --- |
+| `a.7z.001/.002` | ✅ one group, multipart, main `.001` |
+| `a.tar.{gz,bz2,xz}.001/.002` | ✅ one group, multipart, main `.001` |
+| `a.zip` + `a.z01/.z02` | ✅ one group, multipart, main `.zip` |
+| `a.rar` + `a.r00/.r01` | ✅ one group, multipart, main `.rar` |
+| `a.part1.rar/.part2.rar` (and padded) | ✅ one group, multipart, main `.part1` |
+| `a.zip.001/.002` | ⚠️ one group but **not multipart** (single path; `.002` left behind) |
+| `a.rar.001/.002` | ❌ **two groups** (base parsed as `a.rar`) |
+| `a.iso.001` / `a.<ext>.001` | ❌ **two groups** |
+| `a.zipx` + `a.zx01` | ❌ **three groups** |
+| `a.arj` + `a.a01` | ❌ **three groups** |
+| `a.ace` + `a.c00` | ❌ **three groups** |
+
+Constraints: Windows-only; the bundled `7z.exe` is the only engine and **cannot
+decode ACE**; tests mock the subprocess (no real `7z.exe`), so all logic here must
+be unit-testable from filenames alone.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Recognize 7-Zip generic numbered volume splits `name.<ext>.NNN` for **any**
+  `<ext>` (zip, rar, iso, bin, …) as one multipart set with `.001` as the
+  primary entry point.
+- Recognize native ZIPX (`.zipx`/`.zxNN`), ARJ (`.arj`/`.aNN`), ACE
+  (`.ace`/`.cNN`) sets as one group with the correct primary.
+- Keep every part of a set in a single `ArchiveGroup`; never select a
+  continuation as the entry point; never treat a continuation as a nested
+  archive during recursive extraction.
+- Preserve all existing supported formats unchanged (regression-guarded).
+- Preserve the deletion/retention safety model unchanged.
+
+**Non-Goals:**
+- Bare numeric splits with no archive token (`name.001/.002` with `name` having
+  no extension) — out of scope (a separate concern; the earlier bug fix already
+  keeps them safe).
+- 1- and 2-digit numeric volume suffixes (`.1`, `.01`) — out of scope; only
+  zero-padded ≥3-digit suffixes (what 7-Zip emits) are treated as volumes.
+- Making ACE *extractable* — impossible with the bundled engine. ACE is
+  recognized/grouped only; extraction failure is surfaced normally.
+- Refactoring the existing duplicated primary/continuation logic into one module
+  beyond what this change needs (kept atomic).
+
+## Decisions
+
+### D1 — One generic rule for 7-Zip numbered volume splits, ordered after the specific ones
+
+7-Zip's splitter appends a zero-padded numeric run to the *whole* original
+filename, so the canonical shape is `<name>.<ext>.<NNN>`. We add a single generic
+classifier: a basename matching `\.[A-Za-z0-9]+\.\d{3,}$` is a numbered volume
+whose **family extension** is the token immediately before the numeric run and
+whose **base** is everything before that token.
+
+Crucially this rule is applied **after** the existing specific patterns so their
+behavior is preserved:
+- `.7z.NNN` keeps family `7z` (specific rule first).
+- `.tar.{gz,bz2,xz}.NNN` keeps base `name`, family `tar` (specific rule first).
+- `.zip.NNN` keeps family `zip` (existing `\.zip\.\d+$` rule first).
+- `.rar.NNN`, `.iso.NNN`, `.<ext>.NNN` fall through to the generic rule →
+  family = `<ext>`.
+
+Because both parts of a set yield the same `(base, family)`, they group via the
+existing exact base+ext check — no change to grouping flow, only to parsing.
+
+*Alternative considered:* enumerate each extension (`rar`, `iso`, `img`, …).
+Rejected — 7-Zip splits *any* file, so enumeration is endless and brittle. A
+single token-capturing rule covers all cases at zero marginal cost.
+
+### D2 — Primary entry point is the `.001`; classification is filename-only
+
+Extend the entry-point priority so a numbered first volume `\.[A-Za-z0-9]+\.0*1$`
+ranks as a primary (high priority) and numbered continuations rank as
+non-entry-points (zero). `multipart_regex` gains the generic numbered pattern so
+`isMultiPart` becomes true; `first_part_regex` gains the numbered `.001` primary.
+The continuation-skip logic in `archive_utils` and the candidate-key/primary
+helpers gain the generic numbered patterns so continuations are relocated/skipped
+(never recursed into, never chosen as entry).
+
+The "require `.001`" rule from the scope decision is realized as: the `.001`
+ranks above all numbered continuations, so whenever it is present it is chosen as
+`mainArchiveFile`. If `.001` is absent, no high-priority numbered primary exists;
+the set still groups, extraction is attempted and fails, and parts are retained
+(safe — see D5).
+
+### D3 — Native ZIPX / ARJ / ACE via family mapping (mirrors ZIP/RAR)
+
+These behave like the existing ZIP (`.zip`/`.zNN`) and RAR (`.rar`/`.rNN`)
+families: a non-numeric primary plus lettered continuations.
+
+| Format | Primary | Continuation | Family key |
+| --- | --- | --- | --- |
+| ZIPX | `.zipx` | `.zxNN` | `zipx` |
+| ARJ | `.arj` | `.aNN` | `arj` |
+| ACE | `.ace` | `.cNN` | `ace` |
+
+Implementation parallels the existing ZIP/RAR handling: family-map the
+continuation suffix to the family ext in `get_archive_base_name`; map the primary
+extension to the same family; add the continuation patterns to `multipart_regex`;
+rank the primary in `_entry_point_priority` (same tier as `.zip`/`.rar`); add the
+continuations to the `archive_utils` skip/candidate logic. The existing
+`_derive_folder_name` already recognizes `[zrac][0-9]{2}`, so the `a`/`c`
+conventions are already partially anticipated in the codebase.
+
+### D4 — Centralize the new patterns in `regex.py`, reference them elsewhere
+
+To limit the drift hazard, the new generic + ZIPX/ARJ/ACE patterns are defined as
+named constants (and small predicate helpers) in `modules/regex.py`, and the
+other three modules import them rather than re-spelling the regexes. Existing
+duplicated patterns are left in place to keep the change atomic, but new coverage
+goes through the shared definitions.
+
+### D5 — Safety unchanged: success-only deletion absorbs false positives
+
+We deliberately do **not** add an "is this really an archive?" gate at grouping
+time. Ordinary numbered files (e.g. `report.2024.001`) may be classified as a
+volume and an extraction attempt may be made, but originals are deleted only when
+extraction *succeeds* (`_should_delete_original_archives`), and multipart sets are
+retained on failure (`multipart-retention`). So the worst case for a false
+positive is a wasted extraction attempt, never data loss.
+
+### D6 — ACE recognized but not extractable
+
+The bundled 7-Zip cannot decode ACE. ACE sets are grouped correctly (so they
+don't fragment into wrong groups and the user sees one set), but extraction will
+fail and the parts are retained via the normal failure path. This limitation is
+documented in the spec and release notes; no special code path is needed.
+
+## Risks / Trade-offs
+
+- **Generic `\.[A-Za-z0-9]+\.\d{3,}$` over-matches ordinary numbered files**
+  (e.g. `db.backup.001`) → Mitigation: require zero-padded ≥3 digits (matches
+  7-Zip output, excludes `.1`/`.01`); deletion is success-only so misclassified
+  non-archives are retained on the failed extraction attempt.
+- **Single-letter `a\d{2}` / `c\d{2}` continuation patterns collide** with
+  non-archive names like `clip.a01` → Mitigation: the convention is already
+  embedded in the codebase (`[zrac][0-9]{2}`); impact is bounded by success-only
+  deletion; only affects grouping, which is recoverable.
+- **`tar.*` vs generic ordering regression** if the generic rule is mistakenly
+  evaluated first (would reparse `a.tar.gz.001` as base `a.tar`, family `gz`) →
+  Mitigation: explicit ordering (specific patterns first) plus regression tests
+  pinning `a.tar.gz.001 → (a, tar)` and `a.7z.001 → (a, 7z)`.
+- **ACE user confusion** (grouped but won't extract) → Mitigation: clear
+  bilingual failure message path already exists (`ArchiveUnsupportedError`);
+  documented limitation.
+
+## Migration Plan
+
+Pure classification/logic change; no data or config migration. Ship behind no
+flag. Rollback = revert the commit. TDD throughout: each new pattern and each
+touch point gets a failing test first, then the minimal change, with the full
+existing suite kept green as the regression guard.
+
+## Open Questions
+
+- None blocking. Possible follow-ups (out of scope): bare-numeric `name.001`
+  multipart support; centralizing the *existing* duplicated primary/continuation
+  logic into `regex.py` helpers.

--- a/openspec/changes/archive/2026-06-07-expand-multipart-format-detection/proposal.md
+++ b/openspec/changes/archive/2026-06-07-expand-multipart-format-detection/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+The tool only reliably recognizes a subset of multi-part archive naming
+conventions. 7-Zip's generic volume splitter produces `name.<ext>.001/.002/…`
+for **any** source file, yet only `.7z.001` and `.tar.{gz,bz2,xz}.001` are
+detected today — `name.zip.001` (common), `name.rar.001`, `name.iso.001`, and
+any other `<ext>.001` are split into multiple wrong groups or mis-handled as
+single archives, so they fail to extract and leave continuation parts behind.
+WinZip ZIPX splits (`.zx01/.zipx`) and ARJ/ACE multi-volume sets are likewise
+unrecognized. Users with these formats get incorrect grouping and data left
+unextracted.
+
+## What Changes
+
+- Recognize **7-Zip generic numbered volume splits for ANY base extension**:
+  `name.<ext>.001/.002/…` (zero-padded, 3+ digits, requires a `.001` entry) as
+  one multipart set whose primary entry point is the `.001` part. Covers
+  `name.zip.001`, `name.rar.001`, `name.iso.001`, and arbitrary `<ext>`.
+  `name.7z.001` and `name.tar.{gz,bz2,xz}.001` keep their current behavior.
+- Recognize **WinZip ZIPX split**: `name.zx01/.zx02/… + name.zipx`; primary is
+  `name.zipx`, continuations are `.zxNN`.
+- Recognize **ARJ multi-volume**: `name.arj + name.a01/.a02/…`; primary is
+  `name.arj`, continuations are `.aNN`.
+- Recognize **ACE multi-volume**: `name.ace + name.c00/.c01/…`; primary is
+  `name.ace`, continuations are `.cNN`. NOTE: classification/grouping only — the
+  bundled 7-Zip **cannot decode ACE**, so extraction still fails and is surfaced
+  as a normal extraction failure (source parts retained, nothing deleted).
+- Every part of a recognized set groups into **one** `ArchiveGroup` with the
+  correct primary as `mainArchiveFile`; continuation parts are never selected as
+  the extraction entry point and are not treated as nested archives during
+  recursive extraction (they are relocated/skipped like existing continuations).
+- Preserve existing safety: extraction-success is still the only trigger for
+  deleting originals, so a false-positive numbered file (e.g. `report.2024.001`)
+  that is not actually an archive is retained when extraction fails — no data
+  loss.
+
+## Capabilities
+
+### New Capabilities
+
+- `multipart-format-detection`: the canonical catalog of supported multi-part
+  naming conventions across all archive formats; classification of each filename
+  as a primary entry point vs a continuation part; the guarantee that all parts
+  of one set form a single group with the correct primary; and continuation
+  handling during recursive/nested extraction (never an entry point, never a
+  nested archive).
+
+### Modified Capabilities
+
+- `contained-zip-rar-autogrouping`: extend contained-set auto-grouping
+  (`ensure_contained_multipart_groups`) so sets discovered from containers in the
+  output folder are also created for the newly supported formats — generic
+  `name.<ext>.001`, ZIPX, ARJ, ACE — not only ZIP/RAR.
+
+## Impact
+
+- Code (the cross-cutting primary/continuation invariant, kept consistent across
+  files):
+  - `modules/regex.py` — `multipart_regex`, `first_part_regex`.
+  - `classes/ArchiveGroup.py` — `_entry_point_priority`.
+  - `modules/file_utils.py` — `get_archive_base_name`,
+    `ensure_contained_multipart_groups`, `relocate_multipart_parts_from_directory`.
+  - `modules/archive_utils.py` — continuation-skip logic,
+    `_multipart_key_from_basename`, `_is_multipart_primary`,
+    `_find_matching_candidate_parts`.
+- Behavior: more sets correctly recognized and extracted; **no change** to the
+  deletion/retention safety model.
+- Tests: extensive new grouping/classification cases (TDD), plus regression for
+  the existing supported formats.
+- No new dependencies; Windows-only; bundled 7-Zip binary unchanged. ACE remains
+  non-extractable by the bundled engine (documented limitation).

--- a/openspec/changes/archive/2026-06-07-expand-multipart-format-detection/specs/contained-zip-rar-autogrouping/spec.md
+++ b/openspec/changes/archive/2026-06-07-expand-multipart-format-detection/specs/contained-zip-rar-autogrouping/spec.md
@@ -1,43 +1,4 @@
-# contained-zip-rar-autogrouping Specification
-
-## Purpose
-TBD - created by archiving change auto-group-contained-zip-rar-volumes. Update Purpose after archive.
-## Requirements
-### Requirement: Auto-group spanned ZIP sets discovered from containers
-
-When a spanned ZIP set is discovered in the output folder (typically after extracting a container in Step 7), the tool MUST create a multipart group for it so Step 8 can attempt multipart extraction in the same run. Because `.zip` is ambiguous, the tool MUST NOT auto-group a `.zip` unless at least one `.zNN` continuation part is present.
-
-#### Scenario: Create a multipart group when both `.zip` and `.z01` exist
-Given Step 7 has moved files into the output folder and `ensure_contained_multipart_groups(file_paths, groups)` is invoked
-And a directory bucket contains `X.zip` and at least one `X.zNN` continuation part (e.g., `X.z01`)
-When auto-grouping runs
-Then a new multipart `ArchiveGroup` MUST be created for base `X` (if no existing group for the same (dir, base) exists)
-And the group MUST include the `.zip` and the discovered `.zNN` parts
-And the group’s `mainArchiveFile` MUST be set to `X.zip`.
-
-#### Scenario: Do not create a multipart group for a standalone `.zip`
-Given Step 7 has moved files into the output folder and `ensure_contained_multipart_groups(file_paths, groups)` is invoked
-And a directory bucket contains `X.zip` but no `X.zNN` continuation parts
-When auto-grouping runs
-Then no new multipart group MUST be created for `X` based on that `.zip` alone.
-
-### Requirement: Auto-group RAR volume sets discovered from containers
-
-When a RAR volume set is discovered in the output folder (typically after extracting a container in Step 7), the tool MUST create a multipart group for it so Step 8 can attempt multipart extraction in the same run. Because `.rar` is ambiguous, the tool MUST NOT auto-group a `.rar` unless at least one `.rNN` continuation part is present.
-
-#### Scenario: Create a multipart group when both `.rar` and `.r00` exist
-Given Step 7 has moved files into the output folder and `ensure_contained_multipart_groups(file_paths, groups)` is invoked
-And a directory bucket contains `X.rar` and at least one `X.rNN` continuation part (e.g., `X.r00`)
-When auto-grouping runs
-Then a new multipart `ArchiveGroup` MUST be created for base `X` (if no existing group for the same (dir, base) exists)
-And the group MUST include the `.rar` and the discovered `.rNN` parts
-And the group’s `mainArchiveFile` MUST be set to `X.rar`.
-
-#### Scenario: Do not create a multipart group for a standalone `.rar`
-Given Step 7 has moved files into the output folder and `ensure_contained_multipart_groups(file_paths, groups)` is invoked
-And a directory bucket contains `X.rar` but no `X.rNN` continuation parts
-When auto-grouping runs
-Then no new multipart group MUST be created for `X` based on that `.rar` alone.
+## ADDED Requirements
 
 ### Requirement: Auto-group generic numbered volume sets discovered from containers
 
@@ -70,4 +31,3 @@ Then no new multipart group MUST be created for `X` based on that `.rar` alone.
 #### Scenario: Create a multipart group when both .ace and .c00 exist
 - **WHEN** a directory bucket contains `X.ace` and at least one `X.cNN` continuation part and auto-grouping runs
 - **THEN** a new multipart `ArchiveGroup` is created for base `X` with `mainArchiveFile` set to `X.ace`
-

--- a/openspec/changes/archive/2026-06-07-expand-multipart-format-detection/specs/multipart-format-detection/spec.md
+++ b/openspec/changes/archive/2026-06-07-expand-multipart-format-detection/specs/multipart-format-detection/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Recognize 7-Zip generic numbered volume splits for any base extension
+
+The tool MUST recognize files named `name.{ext}.NNN` (a zero-padded numeric suffix of 3 or more digits) as one 7-Zip generic volume split, for any base extension `{ext}` (e.g. `zip`, `rar`, `iso`, `bin`). All parts of the set MUST be placed in one `ArchiveGroup`, the group MUST be marked multipart, and `mainArchiveFile` MUST be the `.001` part (the lowest numbered volume), regardless of the order the files are added. The existing behavior for `name.7z.NNN` and `name.tar.{gz,bz2,xz}.NNN` MUST be preserved unchanged.
+
+#### Scenario: Split ZIP volumes group with the .001 as primary
+- **WHEN** `create_groups_by_name` processes `a.zip.001` and `a.zip.002` in one directory
+- **THEN** exactly one group is produced, it is multipart, and its `mainArchiveFile` is `a.zip.001`
+
+#### Scenario: Split RAR volumes group with the .001 as primary
+- **WHEN** `create_groups_by_name` processes `a.rar.001` and `a.rar.002` in one directory
+- **THEN** exactly one group is produced, it is multipart, and its `mainArchiveFile` is `a.rar.001`
+
+#### Scenario: Split ISO (arbitrary extension) volumes group with the .001 as primary
+- **WHEN** `create_groups_by_name` processes `a.iso.001` and `a.iso.002` in one directory
+- **THEN** exactly one group is produced, it is multipart, and its `mainArchiveFile` is `a.iso.001`
+
+#### Scenario: Existing 7z and tar split parsing is preserved
+- **WHEN** `get_archive_base_name` parses `a.7z.001` and `a.tar.gz.001`
+- **THEN** `a.7z.001` yields base `a` and family `7z`, and `a.tar.gz.001` yields base `a` and family `tar`
+
+#### Scenario: Primary selection is independent of insertion order
+- **WHEN** a group is built by adding `a.zip.002` before `a.zip.001`
+- **THEN** `mainArchiveFile` is still `a.zip.001`
+
+### Requirement: Numbered continuation parts are never entry points or nested archives
+
+A numbered continuation part `name.<ext>.NNN` with `NNN` not equal to 1 MUST NOT
+be selected as `mainArchiveFile`, MUST NOT be treated as a nested archive during
+recursive extraction, and MUST be relocated next to its primary or skipped like
+other multipart continuations.
+
+#### Scenario: Continuation discovered during nested extraction is not recursed into
+- **WHEN** recursive extraction encounters `name.zip.002` among extracted files
+- **THEN** it is relocated to its multipart group or recorded/skipped as a continuation, and is not extracted as a nested archive
+
+#### Scenario: Continuation cannot win primary selection
+- **WHEN** entry-point priority is evaluated for `a.iso.002`
+- **THEN** it scores as a non-entry-point (lower than the `.001` primary)
+
+### Requirement: Recognize WinZip ZIPX split sets
+
+A set named `name.zipx` plus `name.zx01`, `name.zx02`, … MUST be recognized as a
+single multipart set, grouped into one `ArchiveGroup`, marked multipart, with
+`mainArchiveFile` set to `name.zipx`. The `.zxNN` files MUST be classified as
+continuations.
+
+#### Scenario: ZIPX split set groups with .zipx as primary
+- **WHEN** `create_groups_by_name` processes `a.zipx`, `a.zx01`, and `a.zx02` in one directory
+- **THEN** exactly one group is produced, it is multipart, and its `mainArchiveFile` is `a.zipx`
+
+### Requirement: Recognize ARJ multi-volume sets
+
+A set named `name.arj` plus `name.a01`, `name.a02`, … MUST be recognized as a
+single multipart set, grouped into one `ArchiveGroup`, marked multipart, with
+`mainArchiveFile` set to `name.arj`. The `.aNN` files MUST be classified as
+continuations.
+
+#### Scenario: ARJ multi-volume set groups with .arj as primary
+- **WHEN** `create_groups_by_name` processes `a.arj`, `a.a01`, and `a.a02` in one directory
+- **THEN** exactly one group is produced, it is multipart, and its `mainArchiveFile` is `a.arj`
+
+### Requirement: Recognize ACE multi-volume sets (classification only)
+
+A set named `name.ace` plus `name.c00`, `name.c01`, … MUST be recognized as a
+single multipart set, grouped into one `ArchiveGroup`, marked multipart, with
+`mainArchiveFile` set to `name.ace`, and the `.cNN` files classified as
+continuations. Because the bundled 7-Zip engine cannot decode ACE, extraction of
+such a set MUST fail through the normal failure path and the source parts MUST be
+retained (no deletion).
+
+#### Scenario: ACE multi-volume set groups with .ace as primary
+- **WHEN** `create_groups_by_name` processes `a.ace`, `a.c00`, and `a.c01` in one directory
+- **THEN** exactly one group is produced, it is multipart, and its `mainArchiveFile` is `a.ace`
+
+#### Scenario: ACE extraction failure retains source parts
+- **WHEN** extraction of an ACE multipart set fails because the engine cannot decode ACE
+- **THEN** the source `.ace`/`.cNN` parts remain in place and are not deleted, recycled, or moved away
+
+### Requirement: Distinct archive families sharing a base name are not merged
+
+Files that share a base name and directory but belong to different archive families MUST NOT be grouped together; only files of the same family (including its continuation parts) may form a group.
+
+#### Scenario: A standalone .7z is not merged into a spanned .zip set
+- **WHEN** `create_groups_by_name` processes `foo.7z`, `foo.zip`, `foo.z01`, and `foo.z02` in one directory
+- **THEN** two groups are produced: a single-archive group for `foo.7z`, and a multipart group for the spanned zip with `mainArchiveFile` `foo.zip`
+
+### Requirement: Misclassified numbered non-archives are never deleted
+
+The tool MUST NOT delete, recycle, or move away an ordinary numbered file (e.g. `report.2024.001`) that was classified as a volume but is not actually an archive; source deletion happens only after a successful extraction.
+
+#### Scenario: A non-archive numbered file survives a failed extraction attempt
+- **WHEN** a numbered file that is not a valid archive is processed as a multipart primary and extraction fails
+- **THEN** the file remains in place and is not deleted, recycled, or moved away

--- a/openspec/changes/archive/2026-06-07-expand-multipart-format-detection/tasks.md
+++ b/openspec/changes/archive/2026-06-07-expand-multipart-format-detection/tasks.md
@@ -1,0 +1,45 @@
+## 1. Regex foundation (`modules/regex.py`)
+
+- [x] 1.1 Write failing tests for new pattern constants/predicates: generic numbered volume (`name.{ext}.NNN`, 3+ digit), its `.001` primary, and ZIPX/ARJ/ACE continuations (`.zxNN`, `.aNN`, `.cNN`)
+- [x] 1.2 Add named patterns to `regex.py`: extend `multipart_regex` with generic `\.[A-Za-z0-9]+\.\d{3,}`, `zx\d{2}`, `a\d{2}`, `c\d{2}`; extend `first_part_regex` with generic numbered `\.[A-Za-z0-9]+\.0*1`
+- [x] 1.3 Confirm `multipart_regex` still matches existing formats and does NOT match 1/2-digit suffixes (`.1`, `.01`); run regex tests green
+
+## 2. Base-name parsing (`file_utils.get_archive_base_name`)
+
+- [x] 2.1 Write failing tests: `a.zip.001→(a,zip)`, `a.rar.001→(a,rar)`, `a.iso.001→(a,iso)`, `a.zx01→(a,zipx)`, `a.a01→(a,arj)`, `a.c00→(a,ace)`, and regression `a.7z.001→(a,7z)`, `a.tar.gz.001→(a,tar)`
+- [x] 2.2 Add generic numbered rule AFTER the specific patterns; add ZIPX/ARJ/ACE entries to `family_pattern_map`; map `.zipx/.arj/.ace` primaries to their family ext
+- [x] 2.3 Run parsing tests green; verify ordering keeps tar/7z behavior unchanged
+
+## 3. Entry-point priority (`classes/ArchiveGroup._entry_point_priority`)
+
+- [x] 3.1 Write failing tests: `.{ext}.001` ranks as primary (beats `.{ext}.NNN`); `.zipx/.arj/.ace` rank as primaries; continuations score 0
+- [x] 3.2 Add generic numbered `.0*1` primary rule and ZIPX/ARJ/ACE primary rules to `_entry_point_priority`
+- [x] 3.3 Run priority tests green
+
+## 4. Grouping integration (`file_utils.create_groups_by_name`)
+
+- [x] 4.1 Write failing tests for spec scenarios: each set (`a.zip.001/.002`, `a.rar.001/.002`, `a.iso.001/.002`, `a.zipx+.zx01/.zx02`, `a.arj+.a01/.a02`, `a.ace+.c00/.c01`) → exactly one multipart group with the correct `mainArchiveFile`
+- [x] 4.2 Add test that primary selection is insertion-order independent (`.002` added before `.001` still picks `.001`)
+- [x] 4.3 Confirm green with no production change here (driven by tasks 1–3); fix any gap surfaced
+
+## 5. Nested-extraction continuation handling (`modules/archive_utils.py`)
+
+- [x] 5.1 Write failing tests (mocked) that generic numbered continuations and `.zxNN/.aNN/.cNN` are skipped/relocated, never recursed as nested archives, never chosen as entry point
+- [x] 5.2 Extend the continuation-skip block, `_multipart_key_from_basename`, `_is_multipart_primary`, and `_find_matching_candidate_parts` for the new patterns
+- [x] 5.3 Run archive_utils tests green
+
+## 6. Contained auto-grouping (`file_utils.ensure_contained_multipart_groups`)
+
+- [x] 6.1 Write failing tests: contained `X.{ext}.001` creates a group from `.001` alone; contained `.zipx/.arj/.ace` create a group only when a continuation is present; standalone `.arj` alone does not
+- [x] 6.2 Extend `ensure_contained_multipart_groups` to detect generic numbered primaries and ZIPX/ARJ/ACE (with the continuation-required guard)
+- [x] 6.3 Run tests green
+
+## 7. Regression & quality gates
+
+- [x] 7.1 Run full suite (`poetry run pytest -q`) — all green, existing formats unchanged
+- [x] 7.2 Run `black`, `flake8`, `mypy`, and `--help` smoke; fix any issues introduced by this change only
+
+## 8. Documentation
+
+- [x] 8.1 Update the primary/continuation rules in `CLAUDE.md` and `AGENTS.md` to include generic `name.{ext}.001`, ZIPX, ARJ, ACE
+- [x] 8.2 Add a release note for v1.2.1 covering the expanded multipart format coverage, and explicitly note the ACE limitation (recognized/grouped but not extractable by the bundled 7-Zip)

--- a/openspec/specs/multipart-format-detection/spec.md
+++ b/openspec/specs/multipart-format-detection/spec.md
@@ -1,0 +1,99 @@
+# multipart-format-detection Specification
+
+## Purpose
+TBD - created by archiving change expand-multipart-format-detection. Update Purpose after archive.
+## Requirements
+### Requirement: Recognize 7-Zip generic numbered volume splits for any base extension
+
+The tool MUST recognize files named `name.{ext}.NNN` (a zero-padded numeric suffix of 3 or more digits) as one 7-Zip generic volume split, for any base extension `{ext}` (e.g. `zip`, `rar`, `iso`, `bin`). All parts of the set MUST be placed in one `ArchiveGroup`, the group MUST be marked multipart, and `mainArchiveFile` MUST be the `.001` part (the lowest numbered volume), regardless of the order the files are added. The existing behavior for `name.7z.NNN` and `name.tar.{gz,bz2,xz}.NNN` MUST be preserved unchanged.
+
+#### Scenario: Split ZIP volumes group with the .001 as primary
+- **WHEN** `create_groups_by_name` processes `a.zip.001` and `a.zip.002` in one directory
+- **THEN** exactly one group is produced, it is multipart, and its `mainArchiveFile` is `a.zip.001`
+
+#### Scenario: Split RAR volumes group with the .001 as primary
+- **WHEN** `create_groups_by_name` processes `a.rar.001` and `a.rar.002` in one directory
+- **THEN** exactly one group is produced, it is multipart, and its `mainArchiveFile` is `a.rar.001`
+
+#### Scenario: Split ISO (arbitrary extension) volumes group with the .001 as primary
+- **WHEN** `create_groups_by_name` processes `a.iso.001` and `a.iso.002` in one directory
+- **THEN** exactly one group is produced, it is multipart, and its `mainArchiveFile` is `a.iso.001`
+
+#### Scenario: Existing 7z and tar split parsing is preserved
+- **WHEN** `get_archive_base_name` parses `a.7z.001` and `a.tar.gz.001`
+- **THEN** `a.7z.001` yields base `a` and family `7z`, and `a.tar.gz.001` yields base `a` and family `tar`
+
+#### Scenario: Primary selection is independent of insertion order
+- **WHEN** a group is built by adding `a.zip.002` before `a.zip.001`
+- **THEN** `mainArchiveFile` is still `a.zip.001`
+
+### Requirement: Numbered continuation parts are never entry points or nested archives
+
+A numbered continuation part `name.<ext>.NNN` with `NNN` not equal to 1 MUST NOT
+be selected as `mainArchiveFile`, MUST NOT be treated as a nested archive during
+recursive extraction, and MUST be relocated next to its primary or skipped like
+other multipart continuations.
+
+#### Scenario: Continuation discovered during nested extraction is not recursed into
+- **WHEN** recursive extraction encounters `name.zip.002` among extracted files
+- **THEN** it is relocated to its multipart group or recorded/skipped as a continuation, and is not extracted as a nested archive
+
+#### Scenario: Continuation cannot win primary selection
+- **WHEN** entry-point priority is evaluated for `a.iso.002`
+- **THEN** it scores as a non-entry-point (lower than the `.001` primary)
+
+### Requirement: Recognize WinZip ZIPX split sets
+
+A set named `name.zipx` plus `name.zx01`, `name.zx02`, … MUST be recognized as a
+single multipart set, grouped into one `ArchiveGroup`, marked multipart, with
+`mainArchiveFile` set to `name.zipx`. The `.zxNN` files MUST be classified as
+continuations.
+
+#### Scenario: ZIPX split set groups with .zipx as primary
+- **WHEN** `create_groups_by_name` processes `a.zipx`, `a.zx01`, and `a.zx02` in one directory
+- **THEN** exactly one group is produced, it is multipart, and its `mainArchiveFile` is `a.zipx`
+
+### Requirement: Recognize ARJ multi-volume sets
+
+A set named `name.arj` plus `name.a01`, `name.a02`, … MUST be recognized as a
+single multipart set, grouped into one `ArchiveGroup`, marked multipart, with
+`mainArchiveFile` set to `name.arj`. The `.aNN` files MUST be classified as
+continuations.
+
+#### Scenario: ARJ multi-volume set groups with .arj as primary
+- **WHEN** `create_groups_by_name` processes `a.arj`, `a.a01`, and `a.a02` in one directory
+- **THEN** exactly one group is produced, it is multipart, and its `mainArchiveFile` is `a.arj`
+
+### Requirement: Recognize ACE multi-volume sets (classification only)
+
+A set named `name.ace` plus `name.c00`, `name.c01`, … MUST be recognized as a
+single multipart set, grouped into one `ArchiveGroup`, marked multipart, with
+`mainArchiveFile` set to `name.ace`, and the `.cNN` files classified as
+continuations. Because the bundled 7-Zip engine cannot decode ACE, extraction of
+such a set MUST fail through the normal failure path and the source parts MUST be
+retained (no deletion).
+
+#### Scenario: ACE multi-volume set groups with .ace as primary
+- **WHEN** `create_groups_by_name` processes `a.ace`, `a.c00`, and `a.c01` in one directory
+- **THEN** exactly one group is produced, it is multipart, and its `mainArchiveFile` is `a.ace`
+
+#### Scenario: ACE extraction failure retains source parts
+- **WHEN** extraction of an ACE multipart set fails because the engine cannot decode ACE
+- **THEN** the source `.ace`/`.cNN` parts remain in place and are not deleted, recycled, or moved away
+
+### Requirement: Distinct archive families sharing a base name are not merged
+
+Files that share a base name and directory but belong to different archive families MUST NOT be grouped together; only files of the same family (including its continuation parts) may form a group.
+
+#### Scenario: A standalone .7z is not merged into a spanned .zip set
+- **WHEN** `create_groups_by_name` processes `foo.7z`, `foo.zip`, `foo.z01`, and `foo.z02` in one directory
+- **THEN** two groups are produced: a single-archive group for `foo.7z`, and a multipart group for the spanned zip with `mainArchiveFile` `foo.zip`
+
+### Requirement: Misclassified numbered non-archives are never deleted
+
+The tool MUST NOT delete, recycle, or move away an ordinary numbered file (e.g. `report.2024.001`) that was classified as a volume but is not actually an archive; source deletion happens only after a successful extraction.
+
+#### Scenario: A non-archive numbered file survives a failed extraction attempt
+- **WHEN** a numbered file that is not a valid archive is processed as a multipart primary and extraction fails
+- **THEN** the file remains in place and is not deleted, recycled, or moved away
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "complex-unzip-tool-v2"
-version = "1.2.0"
+version = "1.2.1"
 description = "A powerful tool for extracting complex archive files with password support and multipart handling"
 authors = ["Rozx <lisida900710@gmail.com>"]
 readme = "README.md"

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -344,6 +344,65 @@ def test_nested_continuation_parts_skipped_when_not_relocated(monkeypatch, tmp_p
     assert os.path.basename(called_with[0]) == "AnotherSet.7z.003"
 
 
+def test_nested_continuation_parts_relocated_across_all_formats(monkeypatch, tmp_path):
+    """Continuation parts of every supported format found inside nested
+    extraction must be relocated via callback and never counted as finals:
+    generic numbered splits (.zip.002/.rar.002/.iso.002) plus ZIPX/ARJ/ACE
+    continuations (.zx01/.a01/.c00)."""
+    continuation_names = [
+        "Set.zip.002",
+        "Set.rar.002",
+        "Set.iso.002",
+        "Set.zx01",
+        "Set.a01",
+        "Set.c00",
+    ]
+
+    for cont_name in continuation_names:
+        sub = tmp_path / cont_name.replace(".", "_")
+        sub.mkdir()
+        archive_path = str(sub / "outer.7z")
+        output_path = str(sub / "out")
+        (sub / "outer.7z").write_bytes(b"dummy")
+
+        monkeypatch.setattr(
+            au,
+            "is_valid_archive",
+            lambda p, *a, **k: os.path.basename(p) == "outer.7z",
+        )
+
+        def fake_extract(archive_path, output_path, *args, _name=cont_name, **kwargs):
+            _ = (archive_path, args, kwargs)
+            os.makedirs(output_path, exist_ok=True)
+            with open(os.path.join(output_path, _name), "wb") as f:
+                f.write(b"part-bytes")
+            return True
+
+        monkeypatch.setattr(au, "extractArchiveWith7z", fake_extract)
+
+        called_with: list[str] = []
+
+        def relocator(path, _sink=called_with):
+            _sink.append(path)
+            return True
+
+        result = au.extract_nested_archives(
+            archive_path=archive_path,
+            output_path=output_path,
+            interactive=False,
+            use_recycle_bin=False,
+            group_relocator=relocator,
+        )
+
+        finals = result.get("final_files") or []
+        assert not any(
+            os.path.basename(p) == cont_name for p in finals
+        ), f"{cont_name} should not be a final file"
+        assert [os.path.basename(p) for p in called_with] == [
+            cont_name
+        ], f"{cont_name} should be relocated as a continuation"
+
+
 def test_nested_multipart_missing_parts_are_preserved_in_final_files(
     monkeypatch, tmp_path
 ):

--- a/tests/test_cloaked_file_detector.py
+++ b/tests/test_cloaked_file_detector.py
@@ -424,20 +424,26 @@ class TestCloakedFileDetector:
         "complex_unzip_tool_v2.modules.cloaked_file_detector.detect_archive_extension"
     )
     def test_verify_with_signature_no_detection(self, mock_detect, detector):
-        """Test signature verification with no detection."""
+        """No archive token in the name and no signature -> reject the guess.
+
+        'test.file' carries no .7z/.rar/.zip token, so the archive type would be
+        a pure guess. Without a real signature it must be rejected, otherwise
+        ordinary files get renamed into bogus multipart parts (e.g. data loss
+        bug where '2382' became '2.7z.382').
+        """
         mock_detect.return_value = None
         result = detector._verify_with_signature("test.file", "7z")
-        assert result is True  # Should be lenient for cloaked files
+        assert result is False
 
     @patch(
         "complex_unzip_tool_v2.modules.cloaked_file_detector.detect_archive_extension"
     )
     @patch("complex_unzip_tool_v2.modules.cloaked_file_detector.print_warning")
     def test_verify_with_signature_exception(self, mock_warning, mock_detect, detector):
-        """Test signature verification with exception."""
+        """On verification error, be conservative and do not rename."""
         mock_detect.side_effect = Exception("Test error")
         result = detector._verify_with_signature("test.file", "7z")
-        assert result is True  # Should assume valid on error
+        assert result is False  # Conservative: skip rename when verification fails
         mock_warning.assert_called_once()
 
     @patch("os.path.exists")
@@ -589,6 +595,68 @@ class TestCloakedFileDetector:
             assert info["rules_by_type"] == {}
             assert info["highest_priority"] == 0
             assert info["lowest_priority"] == 0
+
+
+class TestCloakedFalsePositives:
+    """Regression tests: ordinary, non-archive files must never be misdetected
+    as cloaked multipart archive parts.
+
+    Bug report: a plain file named like ``2382`` was renamed to ``2.7z.382``
+    (treating the trailing three digits as a 7z multipart part number) and then
+    deleted at the end without ever being extracted, causing data loss. The
+    rename came from the weak ``cloaked_extensionless_direct_digits`` rule whose
+    only safety net -- ``_verify_with_signature`` -- always returned ``True``.
+    """
+
+    # pylint: disable=protected-access
+    @pytest.fixture
+    def detector_with_real_config(self):
+        """Detector backed by the shipped production rules file."""
+        config_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "complex_unzip_tool_v2",
+            "config",
+            "cloaked_file_rules.json",
+        )
+        with patch.object(CloakedFileRule, "__post_init__", return_value=None):
+            return CloakedFileDetector(config_path)
+
+    def test_non_archive_trailing_digits_not_detected(
+        self, detector_with_real_config, tmp_path
+    ):
+        """A real, non-archive file named ``2382`` must not become ``2.7z.382``."""
+        f = tmp_path / "2382"
+        f.write_bytes(b"this is plain data, definitely not an archive\n")
+
+        result = detector_with_real_config.detect_cloaked_file(str(f))
+
+        assert result is None
+
+    def test_non_archive_trailing_digits_uncloak_keeps_file(
+        self, detector_with_real_config, tmp_path
+    ):
+        """uncloak_file must leave a non-archive digit-suffixed file untouched."""
+        f = tmp_path / "2392"
+        f.write_bytes(b"more plain data\n")
+
+        new_path = detector_with_real_config.uncloak_file(str(f))
+
+        assert new_path == str(f)
+        assert os.path.exists(str(f))
+        assert not os.path.exists(str(tmp_path / "2.7z.392"))
+
+    def test_real_7z_first_part_still_detected(
+        self, detector_with_real_config, tmp_path
+    ):
+        """A genuine cloaked 7z first part (valid signature) is still uncloaked."""
+        f = tmp_path / "secret001"
+        # 7z magic bytes so signature verification confirms it is really a 7z.
+        f.write_bytes(b"7z\xbc\xaf\x27\x1c" + b"\x00" * 32)
+
+        result = detector_with_real_config.detect_cloaked_file(str(f))
+
+        assert result is not None
+        assert os.path.basename(result) == "secret.7z.001"
 
 
 class TestCloakedFileDetectorEdgeCases:

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -61,6 +61,40 @@ class TestGetArchiveBaseName:
         assert fu.get_archive_base_name("data.part2.rar") == ("data", "rar")
         assert fu.get_archive_base_name("data.part10.rar") == ("data", "rar")
 
+    def test_generic_numbered_split_returns_token_family(self):
+        """7-Zip generic numbered splits keep the token before the number as the
+        family ext, so all parts of one set share (base, ext)."""
+        assert fu.get_archive_base_name("a.rar.001") == ("a", "rar")
+        assert fu.get_archive_base_name("a.rar.002") == ("a", "rar")
+        assert fu.get_archive_base_name("a.iso.001") == ("a", "iso")
+        assert fu.get_archive_base_name("a.bin.002") == ("a", "bin")
+        assert fu.get_archive_base_name("a.tar.001") == ("a", "tar")
+
+    def test_generic_numbered_split_does_not_change_specific_formats(self):
+        """The generic rule must run AFTER the specific ones: 7z/zip/tar split
+        parsing stays exactly as before."""
+        assert fu.get_archive_base_name("a.7z.001") == ("a", "7z")
+        assert fu.get_archive_base_name("a.zip.001") == ("a", "zip")
+        assert fu.get_archive_base_name("a.tar.gz.001") == ("a", "tar")
+
+    def test_zipx_split_returns_zipx_family(self):
+        """WinZip ZIPX split parts share the .zipx family extension."""
+        assert fu.get_archive_base_name("a.zipx") == ("a", "zipx")
+        assert fu.get_archive_base_name("a.zx01") == ("a", "zipx")
+        assert fu.get_archive_base_name("a.zx02") == ("a", "zipx")
+
+    def test_arj_multivolume_returns_arj_family(self):
+        """ARJ multi-volume parts share the .arj family extension."""
+        assert fu.get_archive_base_name("a.arj") == ("a", "arj")
+        assert fu.get_archive_base_name("a.a01") == ("a", "arj")
+        assert fu.get_archive_base_name("a.a02") == ("a", "arj")
+
+    def test_ace_multivolume_returns_ace_family(self):
+        """ACE multi-volume parts share the .ace family extension."""
+        assert fu.get_archive_base_name("a.ace") == ("a", "ace")
+        assert fu.get_archive_base_name("a.c00") == ("a", "ace")
+        assert fu.get_archive_base_name("a.c01") == ("a", "ace")
+
 
 class TestArchiveGroupMainSelection:
     """Regression tests verifying ArchiveGroup picks the correct main archive
@@ -114,6 +148,60 @@ class TestArchiveGroupMainSelection:
         g.add_file("x.7z.001")
         assert g.mainArchiveFile == "x.7z.001"
 
+    def test_generic_numbered_first_volume_wins(self):
+        """For a 7-Zip generic split of any extension, the `.001` is the entry
+        point regardless of insertion order."""
+        from complex_unzip_tool_v2.classes.ArchiveGroup import ArchiveGroup
+
+        for base, ext in (("x", "rar"), ("y", "iso"), ("z", "bin")):
+            g = ArchiveGroup(f"dir-{base}")
+            g.add_file(f"{base}.{ext}.002")
+            g.add_file(f"{base}.{ext}.001")
+            assert g.mainArchiveFile == f"{base}.{ext}.001"
+            assert g.isMultiPart is True
+
+    def test_zipx_primary_wins_over_continuations(self):
+        from complex_unzip_tool_v2.classes.ArchiveGroup import ArchiveGroup
+
+        for order in (
+            ["a.zipx", "a.zx01", "a.zx02"],
+            ["a.zx01", "a.zx02", "a.zipx"],
+            ["a.zx02", "a.zipx", "a.zx01"],
+        ):
+            g = ArchiveGroup("dir-a")
+            for f in order:
+                g.add_file(f)
+            assert g.mainArchiveFile == "a.zipx", order
+            assert g.isMultiPart is True
+
+    def test_arj_primary_wins_over_continuations(self):
+        from complex_unzip_tool_v2.classes.ArchiveGroup import ArchiveGroup
+
+        for order in (
+            ["a.arj", "a.a01", "a.a02"],
+            ["a.a01", "a.a02", "a.arj"],
+            ["a.a02", "a.arj", "a.a01"],
+        ):
+            g = ArchiveGroup("dir-a")
+            for f in order:
+                g.add_file(f)
+            assert g.mainArchiveFile == "a.arj", order
+            assert g.isMultiPart is True
+
+    def test_ace_primary_wins_over_continuations(self):
+        from complex_unzip_tool_v2.classes.ArchiveGroup import ArchiveGroup
+
+        for order in (
+            ["a.ace", "a.c00", "a.c01"],
+            ["a.c00", "a.c01", "a.ace"],
+            ["a.c01", "a.ace", "a.c00"],
+        ):
+            g = ArchiveGroup("dir-a")
+            for f in order:
+                g.add_file(f)
+            assert g.mainArchiveFile == "a.ace", order
+            assert g.isMultiPart is True
+
 
 class TestCreateGroupsByNameMultipart:
     """End-to-end grouping tests for spanned ZIP / volume RAR (Bugs A+B)."""
@@ -165,6 +253,37 @@ class TestCreateGroupsByNameMultipart:
         groups = fu.create_groups_by_name(files)
         assert len(groups) == 1
         assert groups[0].isMultiPart is True
+
+    def _assert_single_multipart(self, names, expected_main):
+        files = [self._create(n) for n in names]
+        groups = fu.create_groups_by_name(files)
+        assert len(groups) == 1, [g.name for g in groups]
+        g = groups[0]
+        assert g.isMultiPart is True
+        assert os.path.basename(g.mainArchiveFile) == expected_main
+        assert len(g.files) == len(names)
+
+    def test_generic_split_zip_grouped_with_001_as_main(self):
+        self._assert_single_multipart(["a.zip.001", "a.zip.002"], "a.zip.001")
+
+    def test_generic_split_rar_grouped_with_001_as_main(self):
+        self._assert_single_multipart(["a.rar.001", "a.rar.002"], "a.rar.001")
+
+    def test_generic_split_iso_grouped_with_001_as_main(self):
+        self._assert_single_multipart(["a.iso.001", "a.iso.002"], "a.iso.001")
+
+    def test_zipx_split_grouped_with_zipx_as_main(self):
+        self._assert_single_multipart(["a.zipx", "a.zx01", "a.zx02"], "a.zipx")
+
+    def test_arj_multivolume_grouped_with_arj_as_main(self):
+        self._assert_single_multipart(["a.arj", "a.a01", "a.a02"], "a.arj")
+
+    def test_ace_multivolume_grouped_with_ace_as_main(self):
+        self._assert_single_multipart(["a.ace", "a.c00", "a.c01"], "a.ace")
+
+    def test_generic_split_main_independent_of_insertion_order(self):
+        # `.002` created/scanned before `.001` must still pick `.001`.
+        self._assert_single_multipart(["a.iso.002", "a.iso.001"], "a.iso.001")
 
 
 class TestReadDir:
@@ -811,6 +930,102 @@ class TestEnsureContainedMultipartGroups:
 
         groups: list[ArchiveGroup] = []
         created = fu.ensure_contained_multipart_groups([str(p_rar)], groups)
+
+        assert created == 0
+        assert groups == []
+
+    def test_creates_group_for_generic_numbered_split(self, tmp_path):
+        out_dir = tmp_path / "unzipped"
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        p1 = out_dir / "Set.iso.001"
+        p2 = out_dir / "Set.iso.002"
+        p1.write_bytes(b"1")
+        p2.write_bytes(b"2")
+
+        groups: list[ArchiveGroup] = []
+        created = fu.ensure_contained_multipart_groups([str(p1), str(p2)], groups)
+
+        assert created == 1
+        g = groups[0]
+        assert g.isMultiPart is True
+        assert os.path.basename(g.mainArchiveFile).lower().endswith(".iso.001")
+        assert any(f.lower().endswith(".iso.002") for f in g.files)
+
+    def test_creates_group_for_generic_numbered_split_from_001_alone(self, tmp_path):
+        # `.001` is unambiguous, so a group is created even without a sibling.
+        out_dir = tmp_path / "unzipped"
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        p1 = out_dir / "Lonely.rar.001"
+        p1.write_bytes(b"1")
+
+        groups: list[ArchiveGroup] = []
+        created = fu.ensure_contained_multipart_groups([str(p1)], groups)
+
+        assert created == 1
+        assert os.path.basename(groups[0].mainArchiveFile).lower().endswith(".rar.001")
+
+    def test_creates_group_for_zipx_set(self, tmp_path):
+        out_dir = tmp_path / "unzipped"
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        p_zipx = out_dir / "Z.zipx"
+        p_zx01 = out_dir / "Z.zx01"
+        p_zipx.write_bytes(b"zipx")
+        p_zx01.write_bytes(b"zx01")
+
+        groups: list[ArchiveGroup] = []
+        created = fu.ensure_contained_multipart_groups(
+            [str(p_zipx), str(p_zx01)], groups
+        )
+
+        assert created == 1
+        g = groups[0]
+        assert g.isMultiPart is True
+        assert os.path.basename(g.mainArchiveFile).lower().endswith(".zipx")
+
+    def test_creates_group_for_arj_set(self, tmp_path):
+        out_dir = tmp_path / "unzipped"
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        p_arj = out_dir / "A.arj"
+        p_a01 = out_dir / "A.a01"
+        p_arj.write_bytes(b"arj")
+        p_a01.write_bytes(b"a01")
+
+        groups: list[ArchiveGroup] = []
+        created = fu.ensure_contained_multipart_groups([str(p_arj), str(p_a01)], groups)
+
+        assert created == 1
+        assert os.path.basename(groups[0].mainArchiveFile).lower().endswith(".arj")
+
+    def test_creates_group_for_ace_set(self, tmp_path):
+        out_dir = tmp_path / "unzipped"
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        p_ace = out_dir / "C.ace"
+        p_c00 = out_dir / "C.c00"
+        p_ace.write_bytes(b"ace")
+        p_c00.write_bytes(b"c00")
+
+        groups: list[ArchiveGroup] = []
+        created = fu.ensure_contained_multipart_groups([str(p_ace), str(p_c00)], groups)
+
+        assert created == 1
+        assert os.path.basename(groups[0].mainArchiveFile).lower().endswith(".ace")
+
+    def test_does_not_create_group_for_standalone_arj_or_ace(self, tmp_path):
+        out_dir = tmp_path / "unzipped"
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        p_arj = out_dir / "Solo.arj"
+        p_ace = out_dir / "Solo2.ace"
+        p_arj.write_bytes(b"arj")
+        p_ace.write_bytes(b"ace")
+
+        groups: list[ArchiveGroup] = []
+        created = fu.ensure_contained_multipart_groups([str(p_arj), str(p_ace)], groups)
 
         assert created == 0
         assert groups == []

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -377,6 +377,20 @@ class TestShouldGroupFiles:
                 fu._should_group_files("a", "b", "/path/a.zip", "/path/b.zip") is False
             )
 
+    def test_same_base_different_archive_type_not_grouped(self):
+        """Files sharing a base name but with different archive families must
+        NOT be grouped together (e.g. foo.zip vs foo.7z).
+
+        Regression: the similarity (third) check ignored the extension, so a
+        standalone .7z was merged into a spanned .zip group, corrupting both.
+        """
+        assert (
+            fu._should_group_files(
+                "in-foo", "in-foo", r"C:\in\foo.7z", r"C:\in\foo.zip"
+            )
+            is False
+        )
+
 
 class TestAreMultipartRelated:
     """Tests for _are_multipart_related function."""
@@ -464,6 +478,42 @@ class TestCreateGroupsByName:
         # All files should be processed without any validation errors
         groups = fu.create_groups_by_name(self.test_files)
         assert len(groups) > 0  # All files should result in groups
+
+    def test_7z_not_merged_into_spanned_zip_group(self):
+        """A standalone .7z sharing a base name with a spanned .zip set must
+        stay in its own group, not get merged into the multipart zip group.
+
+        Regression for the reported bug where a .7z grouped with a .zip/.z01
+        set caused the .7z to be deleted (and the zip mishandled).
+        """
+        files = [
+            r"C:\in\foo.7z",
+            r"C:\in\foo.zip",
+            r"C:\in\foo.z01",
+            r"C:\in\foo.z02",
+        ]
+        groups = fu.create_groups_by_name(files)
+
+        # Exactly two groups: the standalone 7z, and the spanned zip set.
+        assert len(groups) == 2
+
+        by_main = {os.path.basename(g.mainArchiveFile): g for g in groups}
+
+        # The 7z is its own single (non-multipart) group containing only itself.
+        assert "foo.7z" in by_main
+        sevenz_group = by_main["foo.7z"]
+        assert sevenz_group.isMultiPart is False
+        assert sevenz_group.files == [r"C:\in\foo.7z"]
+
+        # The spanned zip set is multipart with .zip as the main entry point.
+        assert "foo.zip" in by_main
+        zip_group = by_main["foo.zip"]
+        assert zip_group.isMultiPart is True
+        assert set(zip_group.files) == {
+            r"C:\in\foo.zip",
+            r"C:\in\foo.z01",
+            r"C:\in\foo.z02",
+        }
 
 
 class TestMoveFilesPreservingStructure:

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -1,0 +1,80 @@
+"""Unit tests for multipart detection regex patterns."""
+
+import re
+
+from complex_unzip_tool_v2.modules.regex import multipart_regex, first_part_regex
+
+
+def _is_multipart(name: str) -> bool:
+    return bool(re.search(multipart_regex, name, re.IGNORECASE))
+
+
+def _is_first_part(name: str) -> bool:
+    return bool(re.search(first_part_regex, name, re.IGNORECASE))
+
+
+class TestMultipartRegex:
+    """multipart_regex must match every supported continuation/volume form."""
+
+    def test_existing_formats_still_match(self):
+        for name in [
+            "a.7z.001",
+            "a.7z.002",
+            "a.tar.gz.001",
+            "a.tar.bz2.002",
+            "a.z01",
+            "a.r00",
+            "a.part1.rar",
+            "a.part2.rar",
+        ]:
+            assert _is_multipart(name), name
+
+    def test_generic_numbered_split_any_extension(self):
+        for name in [
+            "a.zip.001",
+            "a.zip.002",
+            "a.rar.001",
+            "a.iso.001",
+            "a.bin.002",
+            "a.tar.001",
+        ]:
+            assert _is_multipart(name), name
+
+    def test_zipx_arj_ace_continuations_match(self):
+        for name in ["a.zx01", "a.zx02", "a.a01", "a.a02", "a.c00", "a.c01"]:
+            assert _is_multipart(name), name
+
+    def test_non_multipart_names_do_not_match(self):
+        # Standalone primaries and ordinary files are not continuations.
+        for name in [
+            "a.zip",
+            "a.7z",
+            "a.rar",
+            "a.zipx",
+            "a.arj",
+            "a.ace",
+            "movie.mp4",
+            "a.001",  # bare numeric, no archive token before the number
+        ]:
+            assert not _is_multipart(name), name
+
+    def test_one_and_two_digit_numeric_suffix_not_multipart(self):
+        # Only zero-padded 3+ digit volume suffixes count (what 7-Zip emits).
+        for name in ["a.zip.1", "a.zip.01", "a.iso.1"]:
+            assert not _is_multipart(name), name
+
+
+class TestFirstPartRegex:
+    """first_part_regex marks only the unambiguous numbered entry point."""
+
+    def test_existing_first_parts_match(self):
+        for name in ["a.7z.001", "a.tar.gz.001", "a.part1.rar"]:
+            assert _is_first_part(name), name
+
+    def test_generic_numbered_first_part_matches(self):
+        for name in ["a.zip.001", "a.rar.001", "a.iso.001"]:
+            assert _is_first_part(name), name
+
+    def test_continuations_are_not_first_parts(self):
+        for name in ["a.zip.002", "a.7z.002", "a.z01", "a.r00", "a.part2.rar"]:
+            assert not _is_first_part(name), name


### PR DESCRIPTION
# Release Notes v1.2.1 / 发布说明 v1.2.1

A focused patch release fixing two **data-loss** bugs in cloaked-file detection and archive grouping. No breaking changes.

一个聚焦的补丁版本，修复了伪装文件检测和档案分组中的两个**数据丢失**问题。无破坏性更改。

## 🐛 Bug Fixes / 错误修复

### Don't rename ordinary files into bogus archive parts / 不再把普通文件改名成伪造的档案分卷
A plain non-archive file whose name ends in digits (e.g. `2382`) could be renamed into a fake 7z multipart part (`2.7z.382`). It was then swept into a same-named real archive set and **deleted at the end without ever being extracted — losing the user's data**.

Root cause: `_verify_with_signature()` always returned `True`, so the weak extensionless/digit-suffix cloaking rules renamed *any* digit-suffixed file.

The signature gate now distinguishes deliberate cloaking from a guess:
- If the name carries an explicit archive token (`.7z` / `.rar` / `.zip`, via `ARCHIVE_TOKEN_RE`), the rename is trusted — continuation parts legitimately have no signature (e.g. `something.7z.002删除`).
- If the type was only **guessed** from a trailing number, a real magic-byte signature is now **required** before renaming.
- On verification error the tool is now conservative and **skips** the rename instead of assuming the file is valid.

Genuine cloaked first parts and `.7z.00N删` style parts still uncloak correctly.

名字以数字结尾的普通（非档案）文件（例如 `2382`）原先可能被改名成伪造的 7z 分卷（`2.7z.382`），随后被并入同名的真实档案集合，**在结尾被删除却从未解压 —— 导致用户数据丢失**。

根因：`_verify_with_signature()` 永远返回 `True`，导致弱规则（无扩展名 / 尾部数字）会改名**任何**带数字后缀的文件。

签名校验现在区分"有意伪装"与"猜测"：
- 名字中带有显式档案标记（`.7z` / `.rar` / `.zip`，由 `ARCHIVE_TOKEN_RE` 识别）时，信任改名 —— 续卷本来就没有签名（例如 `something.7z.002删除`）。
- 若类型只是从尾部数字**猜测**得到，改名前现在**必须**有真实的魔数签名。
- 校验出错时改为保守处理，**跳过**改名，而不是假定文件有效。

真正的伪装首卷以及 `.7z.00N删` 之类的分卷仍能正确还原。

### Don't merge different archive types that share a base name / 不再合并同名但类型不同的档案
The similarity check in `_should_group_files` ignored the archive extension, so a standalone `.7z` could be swept into a spanned `.zip` / `.z01` group when they shared a base name and directory. The merged multipart group then **deleted the `.7z` along with the zip parts (data loss)** and mishandled the set during extraction.

Fix: the similarity path now requires `ext1 == ext2`, so only same-family archives group that way. `.zip` / `.z01` still group via the exact `(base, ext)` check, and `foo.7z` stays its own single group alongside the `foo.zip` / `foo.z01` set.

`_should_group_files` 的相似度判断忽略了档案扩展名，导致独立的 `.7z` 在与跨卷 `.zip` / `.z01` 同名且同目录时被并入同一组。合并后的多卷组随后**把 `.7z` 连同 zip 分卷一起删除（数据丢失）**，解压时也处理错误。

修复：相似度路径现在要求 `ext1 == ext2`，只有同家族档案才走该路径分组。`.zip` / `.z01` 仍通过精确的 `(base, ext)` 判断分组，而 `foo.7z` 与 `foo.zip` / `foo.z01` 集合并存时保持为独立的单档案组。

## ✅ Test Coverage / 测试覆盖

### New/Updated Tests / 新增/更新测试
- **Cloaked false-positives** (`TestCloakedFalsePositives`): a plain `2382` file is not detected/renamed, `uncloak_file` leaves a non-archive digit-suffixed file untouched, and a genuine cloaked 7z first part (real magic bytes) still uncloaks to `secret.7z.001`. Two existing `_verify_with_signature` tests were updated to pin the stricter behavior.
- **Grouping guard**: unit (`_should_group_files`) regression that `foo.7z` vs `foo.zip` are not grouped, plus an integration (`create_groups_by_name`) regression asserting `foo.7z` stays a standalone group while `foo.zip` / `.z01` / `.z02` form one spanned set.

Total: **168 tests pass** (was 163 in v1.2.0, +5 new).

- **伪装误报**（`TestCloakedFalsePositives`）：普通的 `2382` 文件不会被检测/改名；`uncloak_file` 对非档案的数字后缀文件保持原样；而真正的伪装 7z 首卷（带真实魔数）仍会还原为 `secret.7z.001`。两个原有的 `_verify_with_signature` 测试更新为锁定更严格的行为。
- **分组守卫**：单元测试（`_should_group_files`）回归确认 `foo.7z` 与 `foo.zip` 不被分到一组；集成测试（`create_groups_by_name`）回归确认 `foo.7z` 保持独立组，而 `foo.zip` / `.z01` / `.z02` 组成一个跨卷集合。

总计：**168 个测试通过**（v1.2.0 是 163 个，新增 5 个）。

## 🚀 Migration Notes / 迁移说明

### For Users / 用户须知
- **No breaking changes.**
- Ordinary files whose names happen to end in digits (e.g. `2382`) are no longer mistaken for archive parts, renamed, or deleted — they are left exactly as they are.
- A standalone `.7z` that shares a base name with a spanned `.zip` set is now extracted on its own instead of being deleted with the zip parts.

- **无破坏性更改。**
- 名字恰好以数字结尾的普通文件（例如 `2382`）不再被误认为档案分卷、被改名或被删除 —— 它们保持原样。
- 与跨卷 `.zip` 集合同名的独立 `.7z` 现在会被单独解压，而不会随 zip 分卷一起被删除。
